### PR TITLE
Remove usage of MessagesSchema byLocations endpoint

### DIFF
--- a/src/components/Insights/ActivityFeed.js
+++ b/src/components/Insights/ActivityFeed.js
@@ -246,7 +246,7 @@ export const ActivityFeed = React.createClass({
 
       SERVICES.FetchMessageSentences(siteKey, originalSource, bbox, datetimeSelection, timespanType, 
                                      limit, offset, edges, DEFAULT_LANGUAGE, Actions.DataSources(filteredSource), 
-                                     categoryValue?categoryValue.name.toLowerCase():categoryValue, searchValue, undefined, callback);
+                                     categoryValue?categoryValue.name.toLowerCase():categoryValue, searchValue, callback);
   },
 
   renderDataSourceTabs(iconStyle){

--- a/src/components/Insights/ActivityFeed.js
+++ b/src/components/Insights/ActivityFeed.js
@@ -243,16 +243,10 @@ export const ActivityFeed = React.createClass({
   fetchSentences(requestPayload, callback){
       let {categoryValue, timespanType, searchValue, limit, offset, edges, siteKey,
            categoryType, filteredSource, bbox, datetimeSelection, originalSource} = requestPayload;
-      let location = [];
-
-      if(categoryType === "Location"){
-          categoryValue = undefined;
-          location = this.state.selectedLocationCoordinates;
-      }
 
       SERVICES.FetchMessageSentences(siteKey, originalSource, bbox, datetimeSelection, timespanType, 
                                      limit, offset, edges, DEFAULT_LANGUAGE, Actions.DataSources(filteredSource), 
-                                     categoryValue?categoryValue.name.toLowerCase():categoryValue, searchValue, location, callback);
+                                     categoryValue?categoryValue.name.toLowerCase():categoryValue, searchValue, undefined, callback);
   },
 
   renderDataSourceTabs(iconStyle){

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -673,7 +673,7 @@ export const SERVICES = {
         request(POST, callback);
     },
 
-    FetchMessageSentences(site, originalSource, bbox, datetimeSelection, timespanType, limit, offset, filteredEdges, langCode, sourceFilter, mainTerm, fulltextTerm, coordinates, callback) {
+    FetchMessageSentences(site, originalSource, bbox, datetimeSelection, timespanType, limit, offset, filteredEdges, langCode, sourceFilter, mainTerm, fulltextTerm, callback) {
         let formatter = Actions.constants.TIMESPAN_TYPES[timespanType];
         let dates = momentGetFromToRange(datetimeSelection, formatter.format, formatter.rangeFormat);
         let fromDate = dates.fromDate, toDate = dates.toDate;

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -704,23 +704,13 @@ export const SERVICES = {
 
             let query, variables;
 
-            if (coordinates && coordinates.length === 2) {
-                query = `  ${fragmentView}
-                       query ByLocation($site: String!, $originalSource: String, $coordinates: [Float]!, $filteredEdges: [String]!, $langCode: String!, $limit: Int!, $offset: Int!, $fromDate: String!, $toDate: String!, $sourceFilter: [String], $fulltextTerm: String) { 
-                             byLocation(site: $site, originalSource: $originalSource, coordinates: $coordinates, filteredEdges: $filteredEdges, langCode: $langCode, limit: $limit, offset: $offset, fromDate: $fromDate, toDate: $toDate, sourceFilter: $sourceFilter, fulltextTerm: $fulltextTerm) {
-                                ...FortisDashboardView 
-                            }
-                        }`;
-                variables = { site, coordinates, filteredEdges, langCode, limit, offset, fromDate, toDate, sourceFilter, fulltextTerm };
-            } else {
-                query = `  ${fragmentView}
-                       query ByBbox($site: String!, $originalSource: String, $bbox: [Float]!, $mainTerm: String, $filteredEdges: [String]!, $langCode: String!, $limit: Int!, $offset: Int!, $fromDate: String!, $toDate: String!, $sourceFilter: [String], $fulltextTerm: String) { 
-                             byBbox(site: $site, originalSource: $originalSource, bbox: $bbox, mainTerm: $mainTerm, filteredEdges: $filteredEdges, langCode: $langCode, limit: $limit, offset: $offset, fromDate: $fromDate, toDate: $toDate, sourceFilter: $sourceFilter, fulltextTerm: $fulltextTerm) {
-                                ...FortisDashboardView 
-                            }
-                        }`;
-                variables = { site, originalSource, bbox, mainTerm, filteredEdges, langCode, limit, offset, fromDate, toDate, sourceFilter, fulltextTerm };
-            }
+            query = `  ${fragmentView}
+                    query ByBbox($site: String!, $originalSource: String, $bbox: [Float]!, $mainTerm: String, $filteredEdges: [String]!, $langCode: String!, $limit: Int!, $offset: Int!, $fromDate: String!, $toDate: String!, $sourceFilter: [String], $fulltextTerm: String) {
+                            byBbox(site: $site, originalSource: $originalSource, bbox: $bbox, mainTerm: $mainTerm, filteredEdges: $filteredEdges, langCode: $langCode, limit: $limit, offset: $offset, fromDate: $fromDate, toDate: $toDate, sourceFilter: $sourceFilter, fulltextTerm: $fulltextTerm) {
+                            ...FortisDashboardView
+                        }
+                    }`;
+            variables = { site, originalSource, bbox, mainTerm, filteredEdges, langCode, limit, offset, fromDate, toDate, sourceFilter, fulltextTerm };
 
             let host = process.env.REACT_APP_SERVICE_HOST
             var POST = {

--- a/test.js
+++ b/test.js
@@ -49,7 +49,7 @@ function FetchMessageSentences(site, bbox, fromDate, toDate, limit, offset, filt
   }
 
   FetchMessageSentences("ocha", [7.734374999999999,26.725986812271756,24.697265625,32.45415593941475],
-                        "11/5/2016", "11/7/2016", 20, 0, ["attack"], "en", undefined, (err, result)=>{
+                        "11/5/2016", "11/7/2016", 20, 0, ["attack"], "en", (err, result)=>{
                             console.log(err);
                             console.log(JSON.stringify(result));
                         });


### PR DESCRIPTION
In Fortis-V1, when the user selects the filter terms, we have a distinction between keywords (like "Isis" or "Bomb") and locations (like "Syria" or "Benghazi"): if we query for all events that contain a keyword, we'll match the keyword in the text, if we query for all events that contain a location, we instead match for the location's coordinates in the event's metadata.

In Fortis-V2, we no longer support this distinction as it's much easier to just treat keywords and locations the same by just using the locations' name as an additional keyword for which to query.

As a result, we need to remove the usage of the MessagesSchema byLocations endpoint in the GraphGL client. Note that the change of deprecating this endpoint has already been made on the GraphQL service, in the branch https://github.com/CatalystCode/project-fortis-services/tree/implement-tiles-resolver