### PR TITLE
Fix potential issue with zoomLevel

### DIFF
--- a/src/services/services.js
+++ b/src/services/services.js
@@ -242,7 +242,7 @@ export const SERVICES = {
         let dates = momentGetFromToRange(datetimeSelection, formatter.format, formatter.rangeFormat);
         let fromDate = dates.fromDate, toDate = dates.toDate;
 
-        const zoomLevel = MAX_ZOOM;
+        const zoomLevel = zoom != null ? zoom : MAX_ZOOM;
 
         console.log(`processing tile request [${mainEdge}, ${timespan}, ${bbox}, ${filteredEdges.join(",")}]`)
         if (bbox && Array.isArray(bbox) && bbox.length === 4) {


### PR DESCRIPTION
The zoom argument passed to this function is the result of calling Leaflet's getZoom in the HeatMap component. Not sure why we'd want to discard the value here and always assume in the back-end that all computations are based on the maximum zoom level?