### PR TITLE
Pass-through conjunctivetopics to GQL backend

### DIFF
--- a/src/services/services.js
+++ b/src/services/services.js
@@ -158,7 +158,7 @@ export const SERVICES = {
                             timeSeries:timeSeries(site: $site, sourceFilter: $sourceFilter, fromDate: $fromDate, toDate: $toDate, mainEdge: $additionalTerms, bbox: $bbox, zoomLevel: $zoomLevel, originalSource: $originalSource){
                                                         ...FortisDashboardTimeSeriesView
                             },
-                            locations: popularLocations(site: $site, timespan: $timespan, sourceFilter: $sourceFilter, originalSource: $originalSource) {
+                            locations: popularLocations(site: $site, timespan: $timespan, sourceFilter: $sourceFilter, originalSource: $originalSource, mainEdge: $additionalTerms) {
                                                         ...FortisDashboardLocationView
                             }${selectedTerm ? `, 
                             topSources(site: $site, fromDate: $fromDate, toDate: $toDate, limit: $limit, mainTerm: $selectedTerm, sourceFilter: $sourceFilter, bbox: $bbox, zoomLevel: $zoomLevel, originalSource: $originalSource) {


### PR DESCRIPTION
Not sure why we're using `mainEdge: $additionalTerms` for the timeseries and popularLocations endpoints but `mainEdge: $selectedTerm` for the topSources endpoint.

Also not sure why we're ignoring the mainEdge argument which is passed into the function and used by most other services to pass the conjunctivetopics to the backend. Could use some help understanding this.