### PR TITLE
Pass-through bbox and zoomLevel to GraphQL

### DIFF
--- a/src/actions/Actions.js
+++ b/src/actions/Actions.js
@@ -163,7 +163,8 @@ const methods = {
                 },
                 chartData: callback => {
                         SERVICES.getChartVisualizationData(siteId, dataStore.datetimeSelection, dataStore.timespanType, undefined, undefined, undefined, 
-                                                           dataSource, fromDate, toDate, (error, response, body) => ResponseHandler(error, response, body, callback))
+                                                           dataSource, fromDate, toDate, dataStore.bbox, dataStore.zoomLevel,
+                                                           (error, response, body) => ResponseHandler(error, response, body, callback))
                 }
             }, (error, results) => {
                     if(!error && Object.keys(results).length === 4
@@ -198,7 +199,7 @@ const methods = {
                 toDate = toDateFilter;
             }
 
-            SERVICES.getChartVisualizationData(siteKey, datetimeSelection, timespanType, selectedEntity, unpopularSelectedTerm, dataStore.categoryValue, dataSource, fromDate, toDate, (err, response, body) => ResponseHandler(err, response, body, (error, graphqlResponse) => {
+            SERVICES.getChartVisualizationData(siteKey, datetimeSelection, timespanType, selectedEntity, unpopularSelectedTerm, dataStore.categoryValue, dataSource, fromDate, toDate, dataStore.bbox, dataStore.zoomLevel, (err, response, body) => ResponseHandler(err, response, body, (error, graphqlResponse) => {
                     if(graphqlResponse) {
                         const {timeSeries, locations, topSources} = graphqlResponse;
                         self.dispatch(constants.DASHBOARD.RELOAD_CHARTS, { selectedEntity: selectedEntity,
@@ -235,8 +236,8 @@ const methods = {
         changeTermsFilterToOnly(newFilter){
            this.dispatch(constants.DASHBOARD.CHANGE_TERM_FILTERS_TO_ONLY, newFilter);
         },
-        updateAssociatedTerms(associatedKeywords, bbox){
-            this.dispatch(constants.DASHBOARD.ASSOCIATED_TERMS, {associatedKeywords, bbox});
+        updateAssociatedTerms(associatedKeywords, bbox, zoomLevel){
+            this.dispatch(constants.DASHBOARD.ASSOCIATED_TERMS, {associatedKeywords, bbox, zoomLevel});
         },
         loadDetail(siteKey, messageId, dataSources, sourcePropeties){
             let self = this;

--- a/src/components/Insights/HeatMap.js
+++ b/src/components/Insights/HeatMap.js
@@ -220,7 +220,7 @@ export const HeatMap = React.createClass({
         this.map.datetimeSelection = state.datetimeSelection;
         this.map.dataSource = state.dataSource;
         this.map.on('moveend',() => {
-            this.getFlux().actions.DASHBOARD.updateAssociatedTerms(this.getStateFromFlux().associatedKeywords, this.getLeafletBbox());
+            this.getFlux().actions.DASHBOARD.updateAssociatedTerms(this.getStateFromFlux().associatedKeywords, this.getLeafletBbox(), this.getLeafletZoomLevel());
         });
 
         this.addClusterGroup();
@@ -302,7 +302,7 @@ export const HeatMap = React.createClass({
       }
   },
 
-  updateDataStore(errors, bbox, filters){
+  updateDataStore(errors, bbox, filters, zoomLevel) {
       let aggregatedAssociatedTermMentions = new Map();
       let self = this;
       let weightedSentiment = weightedMean(this.weightedMeanValues) * 100;
@@ -325,7 +325,7 @@ export const HeatMap = React.createClass({
       this.status = 'loaded';
       //sort the associated terms by mention count.
       let sortedEdgeMap = new Map([...aggregatedAssociatedTermMentions.entries()].sort(this.sortTerms));
-      this.getFlux().actions.DASHBOARD.updateAssociatedTerms(sortedEdgeMap, bbox);
+      this.getFlux().actions.DASHBOARD.updateAssociatedTerms(sortedEdgeMap, bbox, zoomLevel);
       this.breadCrumbControl.update(Array.from(this.state.termFilters));
       this.sentimentGraph.update({weightedSentiment});
   },
@@ -350,6 +350,14 @@ export const HeatMap = React.createClass({
           return undefined;
       }
   },
+
+  getLeafletZoomLevel() {
+    if (!this.map) {
+      return undefined;
+    }
+
+    return this.map.getZoom();
+  },
   
   updateHeatmap() {
     const state = this.getStateFromFlux();
@@ -368,7 +376,7 @@ export const HeatMap = React.createClass({
                                 bbox, Array.from(state.termFilters), [state.selectedLocationCoordinates], Actions.DataSources(state.dataSource), 
                 (error, response, body) => {
                     if (!error && response.statusCode === 200) {
-                        self.createLayers(body, bbox)
+                        self.createLayers(body, bbox, zoom)
                     }else{
                         this.status = 'failed';
                         console.error(`[${error}] occured while processing tile request [${state.categoryValue.name}, ${state.datetimeSelection}, ${bbox}]`);
@@ -377,7 +385,7 @@ export const HeatMap = React.createClass({
     }
   },
   
-  createLayers(response, bbox) {
+  createLayers(response, bbox, zoomLevel) {
     let self = this;
 
     if(response && response.data){
@@ -385,9 +393,9 @@ export const HeatMap = React.createClass({
         if(features && edges){
             eachLimit(features.features, PARELLEL_TILE_LAYER_RENDER_LIMIT, (tileFeature, cb) => {
                  self.processMapCluster(tileFeature, cb);
-            }, errors => self.updateDataStore(errors, bbox, edges.edges || []));
+            }, errors => self.updateDataStore(errors, bbox, edges.edges || [], zoomLevel));
         }else{
-            self.updateDataStore('Invalid GrphQL Service response', bbox, undefined);
+            self.updateDataStore('Invalid GrphQL Service response', bbox, undefined, zoomLevel);
         }
     }
   },

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -144,7 +144,7 @@ const visualizationChartFragments = `fragment FortisDashboardTimeSeriesView on E
                                         }`;
 
 export const SERVICES = {
-    getChartVisualizationData(site, datetimeSelection, timespanType, selectedEntity, unpopularSelectedTerm, mainEdge, dataSource, fromDate, toDate, callback){
+    getChartVisualizationData(site, datetimeSelection, timespanType, selectedEntity, unpopularSelectedTerm, mainEdge, dataSource, fromDate, toDate, bbox, zoomLevel, callback){
         let formatter = Actions.constants.TIMESPAN_TYPES[timespanType];
         let timespan = momentToggleFormats(datetimeSelection, formatter.format, formatter.blobFormat);
         let sourceFilter = Actions.DataSources(dataSource);
@@ -154,19 +154,19 @@ export const SERVICES = {
 
         let query = `${visualizationChartFragments}
                      ${selectedTerm ? `${topSourcesFragment}` : ``}
-                      query PopularEdges($site: String!, $additionalTerms: String, $timespan: String!, $sourceFilter: [String], ${selectedTerm ? `$selectedTerm: String!, $limit: Int!,` : `,`} $fromDate: String!, $toDate: String!) {
-                            timeSeries:timeSeries(site: $site, sourceFilter: $sourceFilter, fromDate: $fromDate, toDate: $toDate, mainEdge: $additionalTerms){
+                      query PopularEdges($site: String!, $additionalTerms: String, $timespan: String!, $sourceFilter: [String], ${selectedTerm ? `$selectedTerm: String!, $limit: Int!,` : `,`} $fromDate: String!, $toDate: String!, $bbox: [Float], $zoomLevel: Int) {
+                            timeSeries:timeSeries(site: $site, sourceFilter: $sourceFilter, fromDate: $fromDate, toDate: $toDate, mainEdge: $additionalTerms, bbox: $bbox, zoomLevel: $zoomLevel){
                                                         ...FortisDashboardTimeSeriesView
                             },
                             locations: popularLocations(site: $site, timespan: $timespan, sourceFilter: $sourceFilter) {
                                                         ...FortisDashboardLocationView
                             }${selectedTerm ? `, 
-                            topSources(site: $site, fromDate: $fromDate, toDate: $toDate, limit: $limit, mainTerm: $selectedTerm, sourceFilter: $sourceFilter) {
+                            topSources(site: $site, fromDate: $fromDate, toDate: $toDate, limit: $limit, mainTerm: $selectedTerm, sourceFilter: $sourceFilter, bbox: $bbox, zoomLevel: $zoomLevel) {
                             ... FortisTopSourcesView
                             }`: ``}
                        }`;
 
-        let variables = { site, additionalTerms, selectedTerm, timespan, limit, sourceFilter, fromDate, toDate };
+        let variables = { site, additionalTerms, selectedTerm, timespan, limit, sourceFilter, fromDate, toDate, bbox, zoomLevel };
         let host = process.env.REACT_APP_SERVICE_HOST;
         let POST = {
             url: `${host}/api/edges`,

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -27,6 +27,7 @@ export const DataStore = Fluxxor.createStore({
           termFilters: new Set(),
           allEdges: new Map(),
           bbox: [],
+          zoomLevel: 8,
           colorMap: new Map(),
           selectedLocationCoordinates: [],
           categoryValue: false,
@@ -207,6 +208,7 @@ export const DataStore = Fluxxor.createStore({
         this.dataStore.associatedKeywords = heatmapData.associatedKeywords;
         this.syncAssociatedTermsSelections(this.dataStore.termFilters);
         this.dataStore.bbox = heatmapData.bbox;
+        this.dataStore.zoomLevel = heatmapData.zoomLevel;
         this.emit("change");
     }
 });


### PR DESCRIPTION
As per new schema, we now want timeSeries and topSources to be adaptive based on the current bounding box.