### PR TITLE
Pass-through originalSource for Tiles schema

### DIFF
--- a/src/components/Insights/HeatMap.js
+++ b/src/components/Insights/HeatMap.js
@@ -366,6 +366,7 @@ export const HeatMap = React.createClass({
     if(state.categoryValue.name){
         SERVICES.getHeatmapTiles(siteKey, state.timespanType, zoom, state.categoryValue.name, state.datetimeSelection, 
                                 bbox, Array.from(state.termFilters), [state.selectedLocationCoordinates], Actions.DataSources(state.dataSource), 
+                                state.originalSource,
                 (error, response, body) => {
                     if (!error && response.statusCode === 200) {
                         self.createLayers(body, bbox)

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -236,7 +236,7 @@ export const SERVICES = {
   },
 
   getHeatmapTiles(site, timespanType, zoom, mainEdge, datetimeSelection, bbox,
-        filteredEdges, locations, sourceFilter, callback) {
+        filteredEdges, locations, sourceFilter, originalSource, callback) {
         const formatter = Actions.constants.TIMESPAN_TYPES[timespanType];
         const timespan = momentToggleFormats(datetimeSelection, formatter.format, formatter.blobFormat);
         let dates = momentGetFromToRange(datetimeSelection, formatter.format, formatter.rangeFormat);
@@ -290,16 +290,16 @@ export const SERVICES = {
             } else {
                 query = `${edgesFragmentView}
                     ${featuresFragmentView}
-                      query FetchAllEdgesAndTilesByBBox($site: String!, $bbox: [Float]!, $mainEdge: String!, $filteredEdges: [String], $timespan: String!, $zoomLevel: Int, $sourceFilter: [String], $fromDate: String, $toDate: String) {
-                            features: fetchTilesByBBox(site: $site, bbox: $bbox, mainEdge: $mainEdge, filteredEdges: $filteredEdges, timespan: $timespan, zoomLevel: $zoomLevel, sourceFilter: $sourceFilter, fromDate: $fromDate, toDate: $toDate) {
+                      query FetchAllEdgesAndTilesByBBox($site: String!, $bbox: [Float]!, $mainEdge: String!, $filteredEdges: [String], $timespan: String!, $zoomLevel: Int, $sourceFilter: [String], $fromDate: String, $toDate: String, originalSource: String) {
+                            features: fetchTilesByBBox(site: $site, bbox: $bbox, mainEdge: $mainEdge, filteredEdges: $filteredEdges, timespan: $timespan, zoomLevel: $zoomLevel, sourceFilter: $sourceFilter, fromDate: $fromDate, toDate: $toDate, originalSource: $originalSource) {
                                 ...FortisDashboardViewFeatures
                             }
-                            edges: fetchEdgesByBBox(site: $site, bbox: $bbox, zoomLevel: $zoomLevel, mainEdge: $mainEdge, timespan: $timespan, sourceFilter: $sourceFilter, fromDate: $fromDate, toDate: $toDate) {
+                            edges: fetchEdgesByBBox(site: $site, bbox: $bbox, zoomLevel: $zoomLevel, mainEdge: $mainEdge, timespan: $timespan, sourceFilter: $sourceFilter, fromDate: $fromDate, toDate: $toDate, originalSource: $originalSource) {
                                 ...FortisDashboardViewEdges
                             }
                         }`;
 
-                variables = { site, bbox, mainEdge, filteredEdges, timespan, zoomLevel, sourceFilter, fromDate, toDate };
+                variables = { site, bbox, mainEdge, filteredEdges, timespan, zoomLevel, sourceFilter, fromDate, toDate, originalSource };
             }
 
             let host = process.env.REACT_APP_SERVICE_HOST


### PR DESCRIPTION
The originalSource gets set in the DataStore via the handleReloadChartData method which is called through the reloadVisualizationState action. Amonst others, this action is wired up to the onClick event in the TopSourcesChart so this should be sufficient for us to wire through the particular source on which the user clicked in the top sources donut chart to the backend (so that we can going forward only fetch the events pertaining to the source that the user selected, e.g. only Tweets from AlJazeera).

Note that there are still other locations where this data needs to be passed through too. This commit just cares about the Tiles schema.