### PR TITLE
Restore by-location query functionality

### DIFF
--- a/src/components/Insights/ActivityFeed.js
+++ b/src/components/Insights/ActivityFeed.js
@@ -243,16 +243,10 @@ export const ActivityFeed = React.createClass({
   fetchSentences(requestPayload, callback){
       let {mainEdge, timespanType, searchValue, limit, offset, edges, siteKey,
            categoryType, filteredSource, bbox, datetimeSelection, originalSource} = requestPayload;
-      let location = [];
-
-      if(categoryType === "Location"){
-          mainEdge = undefined;
-          location = this.state.selectedLocationCoordinates;
-      }
 
       SERVICES.FetchMessageSentences(siteKey, originalSource, bbox, datetimeSelection, timespanType, 
                                      limit, offset, edges, DEFAULT_LANGUAGE, Actions.DataSources(filteredSource), 
-                                     mainEdge, searchValue, location, callback);
+                                     mainEdge, searchValue, this.state.selectedLocationId, callback);
   },
 
   renderDataSourceTabs(iconStyle){

--- a/src/components/Insights/HeatMap.js
+++ b/src/components/Insights/HeatMap.js
@@ -330,15 +330,6 @@ export const HeatMap = React.createClass({
       this.sentimentGraph.update({weightedSentiment});
   },
 
-  moveMapToNewLocation(location, zoom){
-      const originalLocation = this.map.coordinates;
-
-      if(location && location.length > 0 && location[0] !== originalLocation[0] && location[1] !== originalLocation[1]){
-          this.map.setView([location[1], location[0]], zoom);
-          this.map.coordinates = [location[0], location[1]];
-      } 
-  },
-
   getLeafletBbox(){
       if(this.map){
         const bounds = this.map.getBounds();
@@ -365,15 +356,14 @@ export const HeatMap = React.createClass({
     this.clearMap();
     this.status = "loading";
     const siteKey = this.props.siteKey;
-    this.moveMapToNewLocation(state.selectedLocationCoordinates, this.map.getZoom());
     const zoom = this.map.getZoom();
     const bbox = this.getLeafletBbox();
     let self = this;
     this.weightedMeanValues = [];
 
     if (state.mainEdge) {
-        SERVICES.getHeatmapTiles(siteKey, state.timespanType, zoom, state.categoryValue.name, state.datetimeSelection, 
-                                bbox, Array.from(state.termFilters), [state.selectedLocationCoordinates], Actions.DataSources(state.dataSource), 
+        SERVICES.getHeatmapTiles(siteKey, state.timespanType, zoom, state.categoryValue.name, state.datetimeSelection,
+                                bbox, Array.from(state.termFilters), state.selectedLocationId, Actions.DataSources(state.dataSource),
                                 state.originalSource,
                 (error, response, body) => {
                     if (!error && response.statusCode === 200) {

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -673,7 +673,7 @@ export const SERVICES = {
         request(POST, callback);
     },
 
-    FetchMessageSentences(site, originalSource, bbox, datetimeSelection, timespanType, limit, offset, filteredEdges, langCode, sourceFilter, mainTerm, fulltextTerm, coordinates, callback) {
+    FetchMessageSentences(site, originalSource, bbox, datetimeSelection, timespanType, limit, offset, filteredEdges, langCode, sourceFilter, mainTerm, fulltextTerm, placeId, callback) {
         let formatter = Actions.constants.TIMESPAN_TYPES[timespanType];
         let dates = momentGetFromToRange(datetimeSelection, formatter.format, formatter.rangeFormat);
         let fromDate = dates.fromDate, toDate = dates.toDate;
@@ -704,14 +704,14 @@ export const SERVICES = {
 
             let query, variables;
 
-            if (coordinates && coordinates.length === 2) {
+            if (placeId) {
                 query = `  ${fragmentView}
-                       query ByLocation($site: String!, $originalSource: String, $coordinates: [Float]!, $filteredEdges: [String]!, $langCode: String!, $limit: Int!, $offset: Int!, $fromDate: String!, $toDate: String!, $sourceFilter: [String], $fulltextTerm: String) { 
-                             byLocation(site: $site, originalSource: $originalSource, coordinates: $coordinates, filteredEdges: $filteredEdges, langCode: $langCode, limit: $limit, offset: $offset, fromDate: $fromDate, toDate: $toDate, sourceFilter: $sourceFilter, fulltextTerm: $fulltextTerm) {
-                                ...FortisDashboardView 
+                       query ByLocation($site: String!, $originalSource: String, $coordinates: [Float]!, $filteredEdges: [String]!, $langCode: String!, $limit: Int!, $offset: Int!, $fromDate: String!, $toDate: String!, $sourceFilter: [String], $fulltextTerm, $mainTerm: String) {
+                             byLocation(site: $site, originalSource: $originalSource, placeId: $placeId, filteredEdges: $filteredEdges, langCode: $langCode, limit: $limit, offset: $offset, fromDate: $fromDate, toDate: $toDate, sourceFilter: $sourceFilter, fulltextTerm: $fulltextTerm, mainTerm: $mainTerm) {
+                                ...FortisDashboardView
                             }
                         }`;
-                variables = { site, coordinates, filteredEdges, langCode, limit, offset, fromDate, toDate, sourceFilter, fulltextTerm };
+                variables = { site, placeId, filteredEdges, langCode, limit, offset, fromDate, toDate, sourceFilter, fulltextTerm, mainTerm };
             } else {
                 query = `  ${fragmentView}
                        query ByBbox($site: String!, $originalSource: String, $bbox: [Float]!, $mainTerm: String, $filteredEdges: [String]!, $langCode: String!, $limit: Int!, $offset: Int!, $fromDate: String!, $toDate: String!, $sourceFilter: [String], $fulltextTerm: String) { 

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -29,7 +29,7 @@ export const DataStore = Fluxxor.createStore({
           bbox: [],
           zoomLevel: 8,
           colorMap: new Map(),
-          selectedLocationCoordinates: [],
+          selectedLocationId: '',
           categoryValue: false,
           language: 'en'
       }
@@ -128,7 +128,7 @@ export const DataStore = Fluxxor.createStore({
 
         if(selectedEntity){
             this.dataStore.categoryValue = edgeMap.get(selectedEntity[`name_${language}`]);
-            this.dataStore.selectedLocationCoordinates = selectedEntity.coordinates || [];
+            this.dataStore.selectedLocationId = selectedEntity.placeId || '';
             this.dataStore.categoryType = selectedEntity.type;
         }
     },


### PR DESCRIPTION
Now using place-id for queries instead of coordinates as that's what we
have available in the v2 schema.

This is a follow-up to https://github.com/CatalystCode/project-fortis-interfaces/pull/20