### PR TITLE
Refactor header

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -5,61 +5,94 @@ import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 
 export default class Header extends React.Component {
-  changeLanguage(event, index, value){
+  changeLanguage(event, index, value) {
     this.props.flux.actions.DASHBOARD.changeLanguage(value);
   }
 
   render() {
-    const { title, logo, language }  = this.props;
-    const nav = this.renderNav();
-
     return (
       <nav className="navbar navbar-trans" role="navigation">
-          <div>
-              <div className="navbar-header">
-                  <button type="button" className="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapsible">
-                      <span className="sr-only">Toggle navigation</span>
-                      <span className="icon-bar"></span>
-                      <span className="icon-bar"></span>
-                      <span className="icon-bar"></span>
-                  </button>
-                  <a className="navbar-brand text-danger" href="#">
-                     {
-                         logo ? <img role="presentation" src={logo.startsWith("http:") ? logo : `${process.env.PUBLIC_URL}/images/${logo}`} style={{display: 'inline'}} height="48" /> 
-                            : undefined 
-                     }  
-                     <span className="brandLabel">{title}</span>
-                  </a>
-              </div>
-              <div className="navbar-collapse collapse" id="navbar-collapsible">
-                  {nav}
-                { this.props.settings && 
-                 <ul className="nav navbar-nav navbar-right">
-                     <SelectField underlineStyle={{ borderColor: '#337ab7', borderBottom: 'solid 3px' }}
-                                labelStyle={{ fontWeight: 600, color: '#2ebd59' }}
-                                value={language}
-                                autoWidth={true}
-                                style={{maxWidth:'60px'}}
-                                onChange={(event, index, value)=>this.changeLanguage(event, index, value)}>
-                                {this.props.supportedLanguages.map(lang => <MenuItem key={lang} value={lang} primaryText={lang} />)}
-                    </SelectField>
-                  </ul>
-                  }
-              </div>
+        <div>
+          { this.renderNavHeader() }
+          <div className="navbar-collapse collapse" id="navbar-collapsible">
+            { this.renderLeftNav() }
+            { this.renderRightNav() }
           </div>
-     </nav>
-      );
+        </div>
+      </nav>
+    );
   }
 
-  renderNav() {
-      let siteKey = this.props.siteKey;
-      return (
-          <ul className="nav navbar-nav navbar-left">
-              <li><Link to={`/site/${siteKey}/`} activeClassName="current">Dashboard</Link></li>
-              <li><Link to={`/site/${siteKey}/facts/`} activeClassName="current">Facts</Link></li>
-              {this.props.siteKey==="dengue" && <li><Link to={`/site/${siteKey}/predictions/`} activeClassName="current">Predictions</Link></li>}
-          </ul>
-      );
+  renderNavHeader() {
+    const { title, logo, language } = this.props;
+
+    return (
+      <div className="navbar-header">
+        <button type="button" className="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapsible">
+          <span className="sr-only">Toggle navigation</span>
+          <span className="icon-bar"></span>
+          <span className="icon-bar"></span>
+          <span className="icon-bar"></span>
+        </button>
+        <a className="navbar-brand text-danger" href="#">
+          { logo && <img role="presentation" src={logo.startsWith("http:") ? logo : `${process.env.PUBLIC_URL}/images/${logo}`} style={{display: 'inline'}} height="48" /> }
+          <span className="brandLabel">{title}</span>
+        </a>
+      </div>
+    );
   }
 
+  renderLeftNav() {
+    return (
+      <ul className="nav navbar-nav navbar-left">
+        <li>{ this.renderDashboardLink() }</li>
+        <li>{ this.renderFactsLink() }</li>
+        { this.props.siteKey === "dengue" && <li>{ this.renderPredictionsLink() }</li> }
+      </ul>
+    );
+  }
+
+  renderDashboardLink() {
+    return (
+      <Link to={`/site/${this.props.siteKey}/`} activeClassName="current">Dashboard</Link>
+    );
+  }
+
+  renderFactsLink() {
+    return (
+      <Link to={`/site/${this.props.siteKey}/facts/`} activeClassName="current">Facts</Link>
+    );
+  }
+
+  renderPredictionsLink() {
+    return (
+      <Link to={`/site/${this.props.siteKey}/predictions/`} activeClassName="current">Predictions</Link>
+    );
+  }
+
+  renderRightNav() {
+    return (
+      <ul className="nav navbar-nav navbar-right">
+        { this.props.settings && <li>{ this.renderLanguagePicker() }</li> }
+      </ul>
+    );
+  }
+
+  renderLanguagePicker() {
+    const languages = this.props.supportedLanguages.map(lang =>
+      <MenuItem key={lang} value={lang} primaryText={lang} />
+    );
+
+    return (
+      <SelectField
+        underlineStyle={{ borderColor: '#337ab7', borderBottom: 'solid 3px' }}
+        labelStyle={{ fontWeight: 600, color: '#2ebd59' }}
+        value={this.props.language}
+        autoWidth={true}
+        style={{maxWidth:'60px'}}
+        onChange={(event, index, value) => this.changeLanguage(event, index, value)}>
+          {languages}
+      </SelectField>
+    );
+  }
 };

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import '../styles/Header.css';
+import '../../styles/Header.css';
 import { Link } from 'react-router';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import '../../styles/Header.css';
 import { Link } from 'react-router';
-import SelectField from 'material-ui/SelectField';
-import MenuItem from 'material-ui/MenuItem';
 
 import LanguagePicker from './LanguagePicker';
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -6,7 +6,7 @@ import MenuItem from 'material-ui/MenuItem';
 
 import LanguagePicker from './LanguagePicker';
 
-export default class Header extends React.Component {
+class Header extends React.Component {
   render() {
     return (
       <nav className="navbar navbar-trans" role="navigation">
@@ -86,3 +86,5 @@ export default class Header extends React.Component {
     );
   }
 };
+
+export default Header;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -4,11 +4,9 @@ import { Link } from 'react-router';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 
-export default class Header extends React.Component {
-  changeLanguage(event, index, value) {
-    this.props.flux.actions.DASHBOARD.changeLanguage(value);
-  }
+import LanguagePicker from './LanguagePicker';
 
+export default class Header extends React.Component {
   render() {
     return (
       <nav className="navbar navbar-trans" role="navigation">
@@ -79,20 +77,12 @@ export default class Header extends React.Component {
   }
 
   renderLanguagePicker() {
-    const languages = this.props.supportedLanguages.map(lang =>
-      <MenuItem key={lang} value={lang} primaryText={lang} />
-    );
-
     return (
-      <SelectField
-        underlineStyle={{ borderColor: '#337ab7', borderBottom: 'solid 3px' }}
-        labelStyle={{ fontWeight: 600, color: '#2ebd59' }}
-        value={this.props.language}
-        autoWidth={true}
-        style={{maxWidth:'60px'}}
-        onChange={(event, index, value) => this.changeLanguage(event, index, value)}>
-          {languages}
-      </SelectField>
+      <LanguagePicker
+        supportedLanguages={this.props.supportedLanguages}
+        language={this.props.language}
+        flux={this.props.flux}
+      />
     );
   }
 };

--- a/src/components/Header/LanguagePicker.js
+++ b/src/components/Header/LanguagePicker.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default class LanguagePicker extends React.Component {
+  changeLanguage(event, index, value) {
+    this.props.flux.actions.DASHBOARD.changeLanguage(value);
+  }
+
+  render() {
+    const languages = this.props.supportedLanguages.map(lang =>
+      <MenuItem key={lang} value={lang} primaryText={lang} />
+    );
+
+    return (
+      <SelectField
+        underlineStyle={{ borderColor: '#337ab7', borderBottom: 'solid 3px' }}
+        labelStyle={{ fontWeight: 600, color: '#2ebd59' }}
+        value={this.props.language}
+        autoWidth={true}
+        style={{maxWidth:'60px'}}
+        onChange={(event, index, value) => this.changeLanguage(event, index, value)}>
+          {languages}
+      </SelectField>
+    );
+  }
+}

--- a/src/components/Header/LanguagePicker.js
+++ b/src/components/Header/LanguagePicker.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default class LanguagePicker extends React.Component {
+class LanguagePicker extends React.Component {
   changeLanguage(event, index, value) {
     this.props.flux.actions.DASHBOARD.changeLanguage(value);
   }
@@ -23,3 +23,5 @@ export default class LanguagePicker extends React.Component {
     );
   }
 }
+
+export default LanguagePicker;

--- a/src/components/Header/LanguagePicker.js
+++ b/src/components/Header/LanguagePicker.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
 
 class LanguagePicker extends React.Component {
   changeLanguage(event, index, value) {

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,0 +1,3 @@
+import Header from './Header';
+
+export default Header;


### PR DESCRIPTION
Just a bit of refactoring to make the header easier to work with:

- Make spacing consistent
- Extract some methods
- Split into multiple components

No functional change, dashboard still loads as before:

![image](https://user-images.githubusercontent.com/1086421/30313535-fb46c142-979d-11e7-82a0-3388f4896db6.png)
