### PR TITLE
Wire-up CSV exporter

### DIFF
--- a/src/actions/Dashboard/index.js
+++ b/src/actions/Dashboard/index.js
@@ -20,10 +20,10 @@ function fetchCommonTerms(settings, callback, timespanType, fromDate, toDate) {
 }
 
 function fetchFullChartData(fromDate, toDate, periodType, dataSource, maintopic,
-    bbox, zoomLevel, conjunctivetopics, externalsourceid, timeseriesmaintopics, callback) {
+    bbox, zoomLevel, conjunctivetopics, externalsourceid, timeseriesmaintopics, includeCsv, callback) {
 
     DashboardServices.getChartVisualizationData(periodType, maintopic, dataSource, fromDate, toDate, 
-        bbox, zoomLevel, conjunctivetopics, externalsourceid, timeseriesmaintopics, 
+        bbox, zoomLevel, conjunctivetopics, externalsourceid, timeseriesmaintopics, !!includeCsv,
         (err, response, body) => ResponseHandler(err, response, body, callback));
 }
 
@@ -31,10 +31,11 @@ function fetchInitialChartDataCB(resultUnion, fromDate, toDate, timespanType, ca
     const { configuration, topics } = resultUnion;
 
     if (topics.edges.length) {
+        const includeCsv = false;
         const maintopic = topics.edges[0].name;//grab the most commonly mentioned term
         //we're defaulting the timeseriesmaintopics to the most popular on the initial load so we can show all in the timeseries
         fetchFullChartData(fromDate, toDate, timespanType, constants.DEFAULT_DATA_SOURCE, maintopic, configuration.targetBbox,
-            configuration.defaultZoomLevel, [], constants.DEFAULT_EXTERNAL_SOURCE, topics.edges.map(populartopic=>populartopic.name), 
+            configuration.defaultZoomLevel, [], constants.DEFAULT_EXTERNAL_SOURCE, topics.edges.map(populartopic=>populartopic.name), includeCsv,
             (err, chartData) => {
                 const response = Object.assign({}, chartData, resultUnion);
 
@@ -84,13 +85,13 @@ const methods = {
     reloadTopSources(topSources) {
         this.dispatch(constants.DASHBOARD.RELOAD_TOP_SOURCES, topSources);
     },
-    reloadVisualizationState(fromDate, toDate, datetimeSelection, periodType, dataSource, maintopic, bbox, zoomLevel, conjunctivetopics, externalsourceid) {
+    reloadVisualizationState(fromDate, toDate, datetimeSelection, periodType, dataSource, maintopic, bbox, zoomLevel, conjunctivetopics, externalsourceid, includeCsv) {
         let self = this;
         const dataStore = this.flux.stores.DataStore.dataStore;
 
         let timeserieslabels = isMostPopularTopicSelected(maintopic, dataStore.popularTerms) ? dataStore.popularTerms.map(topic=>topic.name) : [maintopic];
 
-        fetchFullChartData(fromDate, toDate, periodType, dataSource, maintopic, bbox, zoomLevel, [], externalsourceid, timeserieslabels, (err, chartData) => {
+        fetchFullChartData(fromDate, toDate, periodType, dataSource, maintopic, bbox, zoomLevel, [], externalsourceid, timeserieslabels, includeCsv, (err, chartData) => {
             if (!err) {
                 let mutatedFilters = { fromDate, toDate, datetimeSelection, periodType, dataSource, maintopic, externalsourceid, zoomLevel, bbox };
                 mutatedFilters.selectedconjunctiveterms = conjunctivetopics;

--- a/src/components/Insights/CsvExporter.js
+++ b/src/components/Insights/CsvExporter.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import Drawer from 'material-ui/Drawer';
+import MenuItem from 'material-ui/MenuItem';
+import RaisedButton from 'material-ui/RaisedButton';
+import FontIcon from 'material-ui/FontIcon';
+
+class CsvExporter extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: false,
+      open: false
+    };
+  }
+
+  handleDrawerToggle = () => {
+    if (!this.hasCsv()) {
+      this.fetchCsvs();
+    }
+    this.setState({open: !this.state.open});
+  }
+
+  handleDrawerChange = (open) => {
+    this.setState({open});
+  }
+
+  render() {
+    return (
+      <div style={{paddingTop: '1em'}}>
+        <RaisedButton
+          label="Export to Excel"
+          icon={<FontIcon className="fa fa-table" />}
+          onClick={this.handleDrawerToggle} />
+        <Drawer
+          docked={false}
+          width={200}
+          open={this.state.open}
+          onRequestChange={this.handleDrawerChange}>
+            {this.renderDrawerContent()}
+        </Drawer>
+      </div>
+    );
+  }
+
+  renderDrawerContent() {
+    if (this.state.loading) {
+      return (
+        <MenuItem>Generating reports...</MenuItem>
+      );
+    }
+
+    const csvsToRender = this.props.csvs.filter(csv => !!csv.url);
+    return csvsToRender.map(this.renderCsv);
+  }
+
+  renderCsv(csv) {
+    return (
+      <MenuItem key={csv.url}>
+        <a href={csv.url}>
+          {csv.name}
+        </a>
+      </MenuItem>
+    );
+  };
+
+  fetchCsvs() {
+    if (!this.state.loading) {
+      this.props.fetchCsvs();
+      this.setState({loading: true});
+    }
+  }
+
+  hasCsv(props) {
+    props = props || this.props;
+    return props.csvs.some(csv => !!csv.url);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const isCsvReady = this.hasCsv(nextProps);
+    if (isCsvReady) {
+      this.setState({loading: false});
+    }
+  }
+}
+
+export default CsvExporter;

--- a/src/components/Insights/Dashboard.js
+++ b/src/components/Insights/Dashboard.js
@@ -4,6 +4,7 @@ import HeatMap from './Maps/HeatMap';
 import SentimentTreeview from './SentimentTreeview';
 import GraphCard from '../Graphics/GraphCard';
 import ActivityFeed from './ActivityFeed';
+import CsvExporter from './CsvExporter';
 import TimeSeriesGraph from './TimeSeriesGraph';
 import PopularTermsChart from './PopularTermsChart';
 import PopularLocationsChart from './PopularLocationsChart';
@@ -162,9 +163,9 @@ export default class Dashboard extends React.Component {
     );
   }
 
-  refreshDashboard(){
+  refreshDashboard(includeCsv) {
     const { dataSource, timespanType, termFilters, datetimeSelection, zoomLevel, maintopic, bbox, fromDate, toDate, externalsourceid } = this.filterLiterals();
-    this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid);
+    this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv);
   }
 
   timelineComponent() {
@@ -214,6 +215,15 @@ export default class Dashboard extends React.Component {
               heatmapToggleText={this.state.heatmapToggleText}
               toggleHeatmapSize={this.toggleHeatmapSize}
               {...this.filterLiterals() }
+            />
+            <CsvExporter
+              csvs={[
+                {name: 'Timeseries', url: this.props.timeSeriesCsv},
+                {name: 'Top locations', url: this.props.popularLocationsCsv},
+                {name: 'Top terms', url: this.props.popularTermsCsv},
+                {name: 'Top sources', url: this.props.topSourcesCsv},
+              ]}
+              fetchCsvs={() => this.refreshDashboard(true)}
             />
             <div className="row" id="contentArea">
               <div className="dashboard-grid">

--- a/src/routes/EntryPage.js
+++ b/src/routes/EntryPage.js
@@ -16,12 +16,14 @@ export const EntryPage = React.createClass({
     const { dataSource, bbox, termFilters, maintopic, externalsourceid, datetimeSelection, 
             fromDate, toDate, language, zoomLevel, settings, timespanType, 
             conjunctivetopics, heatmapTileIds, timeSeriesGraphData, popularLocations, popularTerms,
+            timeSeriesCsv, popularLocationsCsv, popularTermsCsv, topSourcesCsv,
             topSources, trustedSources, fullTermList } = this.state;
 
     return Object.assign({}, { dataSource, maintopic, termFilters, bbox, 
                                externalsourceid, datetimeSelection, fromDate, toDate, language,
                                zoomLevel, settings, timespanType, heatmapTileIds, 
                                conjunctivetopics, timeSeriesGraphData, popularLocations, popularTerms,
+                               timeSeriesCsv, popularLocationsCsv, popularTermsCsv, topSourcesCsv,
                                topSources, trustedSources, fullTermList });
   },
 

--- a/src/services/Dashboard/index.js
+++ b/src/services/Dashboard/index.js
@@ -21,7 +21,7 @@ function fetchGqlData(endpoint, gqlQueryBody, callback) {
 
 export const SERVICES = {
     getChartVisualizationData(periodType, maintopic, dataSource, fromDate, toDate, bbox,
-        zoomLevel, conjunctivetopics, externalsourceid, timeseriesmaintopics, callback) {
+        zoomLevel, conjunctivetopics, externalsourceid, timeseriesmaintopics, csv, callback) {
         const timePeriodType = constants.TIMESPAN_TYPES[periodType].timeseriesType;
         const topsourcespipelinekey = ActionMethods.DataSources(dataSource);
         const pipelinekeys = constants.DEFAULT_EXTERNAL_SOURCE === externalsourceid 
@@ -42,7 +42,7 @@ export const SERVICES = {
         const variables = {
             bbox, limit, fromDate, topsourcespipelinekey, pipelinekeys,
             toDate, zoomLevel, periodType, timePeriodType, externalsourceid, maintopic,
-            timeseriesmaintopics, conjunctivetopics
+            timeseriesmaintopics, conjunctivetopics, csv
         };
         fetchGqlData(gqlEndpoint, { variables, query }, callback);
     },
@@ -50,6 +50,7 @@ export const SERVICES = {
     getCommonTerms(periodType, fromDate, toDate, bbox, zoomLevel, callback) {
         const pipelinekeys = [constants.DEFAULT_DATA_SOURCE];
         const limit = 5;
+        const csv = false;
         const externalsourceid = constants.DEFAULT_EXTERNAL_SOURCE;
         const selectionFragments = `${DashboardFragments.termsFragment}`;
         const gqlEndpoint = 'edges';
@@ -58,7 +59,8 @@ export const SERVICES = {
 
         const variables = {
             bbox, limit, fromDate, pipelinekeys,
-            toDate, zoomLevel, periodType, externalsourceid
+            toDate, zoomLevel, periodType, externalsourceid,
+            csv
         };
         fetchGqlData(gqlEndpoint, { variables, query }, callback);
     },

--- a/src/services/graphql/fragments/Dashboard/index.js
+++ b/src/services/graphql/fragments/Dashboard/index.js
@@ -26,6 +26,9 @@ export const topSourcesFragment = `fragment FortisTopSourcesView on TopSourcesCo
             mentions,
             avgsentiment
         }
+        csv {
+            url
+        }
     }`;
 
 export const translationEventFragment = `fragment TranslationView on TranslationResult{
@@ -38,6 +41,9 @@ export const termsFragment = ` fragment FortisPopularTermsView on TopTermsCollec
             avgsentiment
             mentions
         }
+        csv {
+            url
+        }
     }`;
 
 export const popularPlacesFragment = ` fragment FortisPopularPlacesView on TopPlacesCollection {
@@ -48,6 +54,9 @@ export const popularPlacesFragment = ` fragment FortisPopularPlacesView on TopPl
             bbox
             mentions
             avgsentiment
+        }
+        csv {
+            url
         }
     }`;
 
@@ -62,6 +71,9 @@ export const visualizationChartFragment = `fragment FortisDashboardTimeSeriesVie
             date
         }
         tiles
+        csv {
+            url
+        }
     }`;
 
 export const conjunctiveTermsFragment = `fragment FortisDashboardConjunctiveTermsView on ConjunctionTermCollection {
@@ -69,6 +81,9 @@ export const conjunctiveTermsFragment = `fragment FortisDashboardConjunctiveTerm
             name
             mentions
             conjunctionterm
+        }
+        csv {
+            url
         }
     }`;
 

--- a/src/services/graphql/queries/Dashboard/index.js
+++ b/src/services/graphql/queries/Dashboard/index.js
@@ -4,19 +4,19 @@ export const getMessagesByBbox = `query ByBbox($externalsourceid: String, $zoomL
  }
  }`;
  
- export const getPopularTerms = `topTerms(bbox: $bbox, limit: $limit, fromDate: $fromDate, toDate: $toDate, pipelinekeys: $pipelinekeys, zoomLevel:$zoomLevel, periodType: $periodType, externalsourceid: $externalsourceid) {
+ export const getPopularTerms = `topTerms(bbox: $bbox, limit: $limit, fromDate: $fromDate, toDate: $toDate, pipelinekeys: $pipelinekeys, zoomLevel:$zoomLevel, periodType: $periodType, externalsourceid: $externalsourceid, csv: $csv) {
      ... FortisPopularTermsView
  }`;
  
- export const getTopSources = `topSources(maintopic:$maintopic, bbox: $bbox, conjunctivetopics: $conjunctivetopics, limit: $limit, fromDate: $fromDate, toDate: $toDate, pipelinekeys: $topsourcespipelinekey, zoomLevel:$zoomLevel, periodType: $periodType) {
+ export const getTopSources = `topSources(maintopic:$maintopic, bbox: $bbox, conjunctivetopics: $conjunctivetopics, limit: $limit, fromDate: $fromDate, toDate: $toDate, pipelinekeys: $topsourcespipelinekey, zoomLevel:$zoomLevel, periodType: $periodType, csv: $csv) {
      ... FortisTopSourcesView
  }`;
  
- export const getTimeSeries = `timeSeries(maintopics:$timeseriesmaintopics, pipelinekeys: $pipelinekeys, fromDate: $fromDate, toDate: $toDate, periodType: $timePeriodType, bbox: $bbox, zoomLevel: $zoomLevel, externalsourceid: $externalsourceid, conjunctivetopics: $conjunctivetopics){
+ export const getTimeSeries = `timeSeries(maintopics:$timeseriesmaintopics, pipelinekeys: $pipelinekeys, fromDate: $fromDate, toDate: $toDate, periodType: $timePeriodType, bbox: $bbox, zoomLevel: $zoomLevel, externalsourceid: $externalsourceid, conjunctivetopics: $conjunctivetopics, csv: $csv){
      ...FortisDashboardTimeSeriesView
  }`;
  
- export const getConjunctiveTerms = `conjunctiveTerms(maintopic:$maintopic, bbox: $bbox, fromDate: $fromDate, toDate: $toDate, pipelinekeys: $pipelinekeys, zoomLevel:$zoomLevel, periodType: $periodType, externalsourceid: $externalsourceid) {
+ export const getConjunctiveTerms = `conjunctiveTerms(maintopic:$maintopic, bbox: $bbox, fromDate: $fromDate, toDate: $toDate, pipelinekeys: $pipelinekeys, zoomLevel:$zoomLevel, periodType: $periodType, externalsourceid: $externalsourceid, csv: $csv) {
      ... FortisDashboardConjunctiveTermsView
  }`;
  
@@ -32,7 +32,7 @@ export const getMessagesByBbox = `query ByBbox($externalsourceid: String, $zoomL
      }
  }`;
  
- export const getPopularPlaces = `topLocations(zoomLevel:$zoomLevel, maintopic:$maintopic, bbox: $bbox, limit: $limit, fromDate: $fromDate, toDate: $toDate, pipelinekeys: $pipelinekeys, conjunctivetopics:$conjunctivetopics, periodType: $periodType, externalsourceid: $externalsourceid) {
+ export const getPopularPlaces = `topLocations(zoomLevel:$zoomLevel, maintopic:$maintopic, bbox: $bbox, limit: $limit, fromDate: $fromDate, toDate: $toDate, pipelinekeys: $pipelinekeys, conjunctivetopics:$conjunctivetopics, periodType: $periodType, externalsourceid: $externalsourceid, csv: $csv) {
      ... FortisPopularPlacesView
  }`;
  
@@ -47,7 +47,7 @@ export const getMessagesByBbox = `query ByBbox($externalsourceid: String, $zoomL
  }`;
  
  
- export const getPopularTermsQuery = `query PopularTerms($bbox: [Float]!, $zoomLevel: Int!, $limit: Int!, $fromDate: String!, $toDate: String!, $pipelinekeys: [String]!, $periodType: String!, $externalsourceid: String!) {
+ export const getPopularTermsQuery = `query PopularTerms($bbox: [Float]!, $zoomLevel: Int!, $limit: Int!, $fromDate: String!, $toDate: String!, $pipelinekeys: [String]!, $periodType: String!, $externalsourceid: String!, $csv: Boolean) {
      topics: ${getPopularTerms}
  }`;
  
@@ -62,7 +62,7 @@ export const getMessagesByBbox = `query ByBbox($externalsourceid: String, $zoomL
  }`;
  
  export const DashboardQuery = `query DashboardQuery($bbox: [Float]!, $zoomLevel: Int!, $limit: Int!, $fromDate: String!, $toDate: String!, 
-                         $pipelinekeys: [String]!, $timePeriodType: String!, $periodType: String!, $externalsourceid: String!, 
+                         $pipelinekeys: [String]!, $timePeriodType: String!, $periodType: String!, $externalsourceid: String!, $csv: Boolean,
                          $maintopic: String!, $timeseriesmaintopics: [String]!, $conjunctivetopics: [String]!, $topsourcespipelinekey: [String]!) {
                              topics: ${getPopularTerms} , 
                              sources: ${getTopSources},

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -43,6 +43,10 @@ export const DataStore = Fluxxor.createStore({
             targetBbox: [],
             popularTerms: [],
             topSources: [],
+            timeSeriesCsv: "",
+            popularLocationsCsv: "",
+            popularTermsCsv: "",
+            topSourcesCsv: "",
             trustedSources: [],
             supportedLanguages: [],
             termFilters: new Set(),
@@ -77,9 +81,12 @@ export const DataStore = Fluxxor.createStore({
     syncChartDataToStore(graphqlResponse){
         const { locations, topics, sources, timeSeries, conjunctiveterms } = graphqlResponse;
         this.dataStore.popularLocations = locations && locations.edges ? locations.edges : [];
+        this.dataStore.popularLocationsCsv = (locations && locations.csv && locations.csv.url) || "";
         this.dataStore.popularTerms = topics && topics.edges ? topics.edges : [];
+        this.dataStore.popularTermsCsv = (topics && topics.csv && topics.csv.url) || "";
         this.dataStore.conjunctivetopics = conjunctiveterms && conjunctiveterms.edges ? conjunctiveterms.edges : [];
         this.dataStore.topSources = sources && sources.edges ? sources.edges : [];
+        this.dataStore.topSourcesCsv = (sources && sources.csv && sources.csv.url) || "";
         this.syncTimeSeriesData(timeSeries || []);
     },
 
@@ -137,6 +144,7 @@ export const DataStore = Fluxxor.createStore({
         if (mutatedTimeSeries && mutatedTimeSeries.graphData && mutatedTimeSeries.labels && mutatedTimeSeries.graphData.length) {
             const { labels, graphData, tiles } = mutatedTimeSeries;
             this.dataStore.timeSeriesGraphData = Object.assign({}, { labels });
+            this.dataStore.timeSeriesCsv = (mutatedTimeSeries.csv && mutatedTimeSeries.csv.url) || "";
             
             const timeseriesMap = makeMap(graphData, item=>item.date, item=>{
                 let timeSeriesEntry = {date: item.date};


### PR DESCRIPTION
## User interface ##

**First, click on the "Export to Excel" button.**

![1](https://user-images.githubusercontent.com/1086421/30327149-50eb14f4-97cb-11e7-8d33-91e694125190.PNG)

**A drawer opens and the CSVs are formatted via GraphQL.**

![2](https://user-images.githubusercontent.com/1086421/30327154-52f92ec0-97cb-11e7-9c87-5b7e5ea48b19.PNG)

**Finally, the reports are ready to be downloaded.**

![3](https://user-images.githubusercontent.com/1086421/30327155-5430e260-97cb-11e7-989b-2c9e41f48150.PNG)

## Development notes ##

If the drawer is re-opened, the previously formatted CSVs are re-used.

If any of the inputs change, the CSVs are re-generated on next click to the export button.

A click outside of the drawer automatically closes it.

~~Relies on this service change: https://github.com/CatalystCode/project-fortis-services/pull/137~~