### PR TITLE
Avoid arrow functions in render()

### DIFF
--- a/src/components/Graphics/DoughnutChart.js
+++ b/src/components/Graphics/DoughnutChart.js
@@ -22,7 +22,7 @@ class CustomTooltip extends Component {
 }
 
 export default class DoughnutChart extends Component {
-    renderActiveShape(props, activeIndex){
+    renderActiveShape = (props) => {
       const RADIAN = Math.PI / 180;
       const { cx, cy, midAngle, innerRadius, outerRadius, startAngle, endAngle,
         fill, payload, value } = props;
@@ -91,7 +91,7 @@ export default class DoughnutChart extends Component {
                     fill={this.props.fill}
                     activeIndex={this.props.activeIndex}
                     data={this.props.data}
-                    activeShape={props=>this.renderActiveShape(props, this.props.activeIndex)} 
+                    activeShape={this.renderActiveShape}
                     paddingAngle={0}
                     {...this.props}>
               {this.props.children}

--- a/src/components/Graphics/Timeline.js
+++ b/src/components/Graphics/Timeline.js
@@ -19,7 +19,7 @@ class Timeline extends Component {
                     <YAxis type="number" tickFormatter={toNumericDisplay}/>
                     <Tooltip />
                     <Brush height={25}
-                        onChange={range=>this.props.dateRangeChanged(range)}
+                        onChange={this.props.dateRangeChanged}
                         dataKey={this.props.dataKey} >
                         <AreaChart data={this.props.data} fill={this.props.fill}>
                             <CartesianGrid />

--- a/src/components/Insights/Dashboard.js
+++ b/src/components/Insights/Dashboard.js
@@ -166,7 +166,7 @@ export default class Dashboard extends React.Component {
     );
   }
 
-  refreshDashboard(includeCsv) {
+  refreshDashboard = (includeCsv) => {
     const { dataSource, timespanType, termFilters, datetimeSelection, zoomLevel, maintopic, bbox, fromDate, toDate, externalsourceid, selectedplace } = this.filterLiterals();
     this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv, selectedplace);
   }
@@ -176,7 +176,7 @@ export default class Dashboard extends React.Component {
       <div key={'timeline'}>
           <TimeSeriesGraph
             allSiteTopics={this.props.fullTermList}
-            refreshDashboardFunction={()=>this.refreshDashboard()}
+            refreshDashboardFunction={this.refreshDashboard}
             timeSeriesGraphData={this.props.timeSeriesGraphData}
             {...this.filterLiterals() }
           />

--- a/src/components/Insights/DataSelector.js
+++ b/src/components/Insights/DataSelector.js
@@ -42,7 +42,7 @@ export default class DataSelector extends React.Component {
         this.setState({ timeType: '' });
     }
 
-    cancelDateTimePicker() {
+    cancelDateTimePicker = () => {
         this.setState({ timeType: '' });
     }
 
@@ -56,7 +56,7 @@ export default class DataSelector extends React.Component {
         this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, timeSelection, dateType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid, null, selectedplace);
     }
 
-    handleChange(event, index, value) {
+    handleChange = (event, index, value) => {
         var selectionOption = TimeSelectionOptions[index];
         
         if(selectionOption.timeType.startsWith("custom")){
@@ -66,7 +66,7 @@ export default class DataSelector extends React.Component {
         }
     }
 
-    handleDatePickerChange(dateObject, dateStr) {
+    handleDatePickerChange = (dateObject, dateStr) => {
         let formatter = constants.TIMESPAN_TYPES[this.state.timeType];
         this.refreshDashboard(momentToggleFormats(dateStr, formatter.reactWidgetFormat, formatter.format), this.state.timeType);
         this.setState({ timeType: 'customDatePlaceholder' });
@@ -114,26 +114,26 @@ export default class DataSelector extends React.Component {
                             <SelectField key="dateSelection" underlineStyle={{ borderColor: '#337ab7', borderBottom: 'solid 3px' }}
                                 labelStyle={{ fontWeight: 600, color: '#2ebd59' }}
                                 value={this.props.datetimeSelection}
-                                onChange={(event, index, value)=>this.handleChange(event, index, value)}>
+                                onChange={this.handleChange}>
                                 {self.predefinedDateOptions(self)}
                             </SelectField>
                             :
                             <DateTimePicker value={new Date()}
-                                onChange={(dateObject, dateStr)=>this.handleDatePickerChange(dateObject, dateStr)}
+                                onChange={this.handleDatePickerChange}
                                 format={constants.TIMESPAN_TYPES[this.state.timeType].reactWidgetFormat}
                                 time={showTimePicker} {...monthSelectorProps} />
                         }
                     </div>
                     <div>
                         {showTimePicker || showDatePicker || showMonthSelector ?
-                            <button id="cancel-button" type="button" className="btn btn-danger btn-sm" onClick={()=>this.cancelDateTimePicker()}>
+                            <button id="cancel-button" type="button" className="btn btn-danger btn-sm" onClick={this.cancelDateTimePicker}>
                                 <span className="fa fa-times-circle-o" aria-hidden="true"></span>&nbsp;Cancel
                 </button>
                             : undefined
                         }
                     </div>
                     <div>
-                        <button id="save-button" type="button" className="btn btn-primary btn-sm" onClick={()=>this.props.toggleHeatmapSize()}>
+                        <button id="save-button" type="button" className="btn btn-primary btn-sm" onClick={this.props.toggleHeatmapSize}>
                             <span className="fa fa-expand" aria-hidden="true">
                             </span>
                             <span>{this.props.heatmapToggleText}</span>

--- a/src/components/Insights/DataSourceFilter.js
+++ b/src/components/Insights/DataSourceFilter.js
@@ -29,9 +29,9 @@ const styles={
 };
 
 export default class DataSourceFilter extends React.Component {
-  radioButtonChanged(e, value){
+  radioButtonChanged = (e, value) => {
       const { timespanType, selectedplace, datetimeSelection, fromDate, toDate, maintopic, bbox, zoomLevel, termFilters, externalsourceid } = this.props;
-    
+
       this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, value, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid, null, selectedplace);
   }
 
@@ -41,7 +41,7 @@ export default class DataSourceFilter extends React.Component {
         buttons.push(<RadioButton labelStyle={styles.radioLabel} style={styles.radioButton} key={source} value={source} label={<div style={styles.labelContainer}><i style={iconStyle} className={value.icon}></i><span style={styles.label}>{value.display}</span></div>} />)
     }
 
-    return <RadioButtonGroup onChange={(e, value)=>this.radioButtonChanged(e, value)} 
+    return <RadioButtonGroup onChange={this.radioButtonChanged}
                              style={styles.buttonGroup} 
                              name="filters" 
                              valueSelected={this.props.dataSource}>

--- a/src/components/Insights/PopularLocationsChart.js
+++ b/src/components/Insights/PopularLocationsChart.js
@@ -16,7 +16,7 @@ export default class PopularLocationsChart extends React.Component {
         };
     }
 
-    handleClick(data, activeIndex) {
+    handleClick = (data, activeIndex) => {
         const { placeid, centroid, bbox, name } = data;
 
         const { dataSource, timespanType, termFilters, defaultZoom, datetimeSelection, maintopic, externalsourceid, fromDate, toDate } = this.props;
@@ -60,7 +60,8 @@ export default class PopularLocationsChart extends React.Component {
 
     render() {
         return (
-            <DoughnutChart handleClick={(data, activeIndex)=>this.handleClick(data, activeIndex)}
+            <DoughnutChart
+                handleClick={this.handleClick}
                 fill={constants.CHART_STYLE.BG_FILL}
                 language={this.props.language}
                 data={this.state.dataProvider}

--- a/src/components/Insights/PopularTermsChart.js
+++ b/src/components/Insights/PopularTermsChart.js
@@ -15,7 +15,7 @@ export default class PopularTermsChart extends React.Component {
         };
     }
 
-    handleClick(data) {
+    handleClick = (data) => {
         const { dataSource, bbox, timespanType, termFilters, datetimeSelection, zoomLevel, externalsourceid, fromDate, toDate, selectedplace } = this.props;
 
         this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, data.defaultName, bbox, zoomLevel, Array.from(termFilters), externalsourceid, null, selectedplace);
@@ -70,7 +70,7 @@ export default class PopularTermsChart extends React.Component {
 
     render() {
         return (
-            <DoughnutChart handleClick={data=>this.handleClick(data)}
+            <DoughnutChart handleClick={this.handleClick}
                 fill={constants.CHART_STYLE.BG_FILL}
                 language={this.props.language}
                 data={this.state.dataProvider}

--- a/src/components/Insights/SentimentTreeview.js
+++ b/src/components/Insights/SentimentTreeview.js
@@ -179,7 +179,7 @@ export default class SentimentTreeview extends React.Component {
         this.handleDataFetch(maintopic, []);
     }
 
-    onFilterMouseUp(e) {
+    onFilterMouseUp = (e) => {
         const filter = e.target.value.trim();
 
         if (!filter) { return this.setState({ treeData: this.state.originalTreeData }); }
@@ -266,7 +266,7 @@ export default class SentimentTreeview extends React.Component {
                         <input type="text"
                             className="form-control edgeFilterInput"
                             placeholder="Search the association list..."
-                            onKeyUp={ev=>self.onFilterMouseUp(ev)} />
+                            onKeyUp={self.onFilterMouseUp} />
                     </div>
                 </div>
                 <div className="list-group" data-scrollable="" style={treeviewStyle}>


### PR DESCRIPTION
The arrow functions means that React has to re-render the component on every cycle given that there's no way to check that the inline arrow functions are constant between renders. As such, it's better to avoid arrow functions in `render()` since they cause performance issues. There are several ways to get around the arrow functions, refer to this article for more context: https://medium.freecodecamp.org/react-binding-patterns-5-approaches-for-handling-this-92c651b5af56

Here, we go for the "arrow functions in class property" approach which is recommended by Facebook for non-legacy code: https://facebook.github.io/react/docs/react-without-es6.html#autobinding
