### PR TITLE
Implement chips to reset filters

### DIFF
--- a/src/components/Insights/ActiveFiltersView.js
+++ b/src/components/Insights/ActiveFiltersView.js
@@ -14,7 +14,7 @@ class ActiveFiltersView extends React.Component {
       chips.push({
         type: 'dataSource',
         label: `Publisher: ${dataSource}`,
-        icon: 'find_in_page',
+        icon: <FontIcon className="material-icons">find_in_page</FontIcon>,
         onDelete: this.props.deleteDataSource,
       });
     }
@@ -24,7 +24,7 @@ class ActiveFiltersView extends React.Component {
       chips.push({
         type: 'externalsourceid',
         label: `Source: ${externalsourceid}`,
-        icon: 'share',
+        icon: <FontIcon className="material-icons">share</FontIcon>,
         onDelete: this.props.deleteExternalSourceId,
       });
     }
@@ -35,7 +35,7 @@ class ActiveFiltersView extends React.Component {
   renderChip = (chip) => {
     return (
       <Chip key={chip.type} onRequestDelete={chip.onDelete} className="active-filters-view--chip">
-        <Avatar icon={<FontIcon className="material-icons">{chip.icon}</FontIcon>} />
+        <Avatar icon={chip.icon} />
         <div className="active-filters-view--chip--label-container" title={chip.label}>
           {chip.label}
         </div>

--- a/src/components/Insights/ActiveFiltersView.js
+++ b/src/components/Insights/ActiveFiltersView.js
@@ -10,26 +10,22 @@ class ActiveFiltersView extends React.Component {
     const chips = [];
 
     const dataSource = this.props.dataSource;
-    if (dataSource) {
+    if (dataSource && dataSource !== DEFAULT_DATA_SOURCE) {
       chips.push({
         type: 'dataSource',
         label: `Publisher: ${dataSource}`,
         icon: 'find_in_page',
-        onDelete: dataSource === DEFAULT_DATA_SOURCE
-          ? undefined
-          : this.props.deleteDataSource,
+        onDelete: this.props.deleteDataSource,
       });
     }
 
     const externalsourceid = this.props.externalsourceid;
-    if (externalsourceid) {
+    if (externalsourceid && externalsourceid !== DEFAULT_EXTERNAL_SOURCE) {
       chips.push({
         type: 'externalsourceid',
         label: `Source: ${externalsourceid}`,
         icon: 'share',
-        onDelete: externalsourceid === DEFAULT_EXTERNAL_SOURCE
-          ? undefined
-          : this.props.deleteExternalSourceId,
+        onDelete: this.props.deleteExternalSourceId,
       });
     }
 

--- a/src/components/Insights/ActiveFiltersView.js
+++ b/src/components/Insights/ActiveFiltersView.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import Avatar from 'material-ui/Avatar';
+import Chip from 'material-ui/Chip';
+import FontIcon from 'material-ui/FontIcon';
+import '../../styles/Insights/ActiveFiltersView.css';
+import { DEFAULT_EXTERNAL_SOURCE, DEFAULT_DATA_SOURCE } from '../../actions/constants';
+
+class ActiveFiltersView extends React.Component {
+  getChips = () => {
+    const chips = [];
+
+    const dataSource = this.props.dataSource;
+    if (dataSource) {
+      chips.push({
+        type: 'dataSource',
+        label: `Publisher: ${dataSource}`,
+        icon: 'find_in_page',
+        onDelete: dataSource === DEFAULT_DATA_SOURCE
+          ? undefined
+          : this.props.deleteDataSource,
+      });
+    }
+
+    const externalsourceid = this.props.externalsourceid;
+    if (externalsourceid) {
+      chips.push({
+        type: 'externalsourceid',
+        label: `Source: ${externalsourceid}`,
+        icon: 'share',
+        onDelete: externalsourceid === DEFAULT_EXTERNAL_SOURCE
+          ? undefined
+          : this.props.deleteExternalSourceId,
+      });
+    }
+
+    return chips;
+  }
+
+  renderChip = (chip) => {
+    return (
+      <Chip key={chip.type} onRequestDelete={chip.onDelete} className="active-filters-view--chip">
+        <Avatar icon={<FontIcon className="material-icons">{chip.icon}</FontIcon>} />
+        <div className="active-filters-view--chip--label-container" title={chip.label}>
+          {chip.label}
+        </div>
+      </Chip>
+    );
+  }
+
+  render() {
+    return (
+      <div className="active-filters-view">
+        {this.getChips().map(this.renderChip)}
+      </div>
+    );
+  }
+}
+
+export default ActiveFiltersView;

--- a/src/components/Insights/SentimentTreeview.js
+++ b/src/components/Insights/SentimentTreeview.js
@@ -214,13 +214,13 @@ export default class SentimentTreeview extends React.Component {
                     }
                 </Subheader>
                 <div style={styles.searchBox}>
-                   { <TypeaheadSearch 
+                    <TypeaheadSearch
                         dashboardRefreshFunc={this.handleDataFetch}
                         bbox={this.props.bbox}
                         language={this.props.language}
                         allSiteTopics={this.props.allSiteTopics}
                         maintopic={this.props.maintopic}
-                        defaultLanguage={this.props.defaultLanguage} /> }
+                        defaultLanguage={this.props.defaultLanguage} />
                 </div>
                 <div style={styles.searchBox}>
                     <div className="input-group">

--- a/src/components/Insights/SentimentTreeview.js
+++ b/src/components/Insights/SentimentTreeview.js
@@ -3,11 +3,13 @@ import React from 'react';
 import { Treebeard, decorators } from 'react-treebeard';
 import * as filters from './TreeFilter';
 import TypeaheadSearch from './TypeaheadSearch';
+import ActiveFiltersView from './ActiveFiltersView';
 import '../../styles/Header.css';
 import '../../styles/Insights/SentimentTreeView.css';
 import { styles, treeDataStyle } from '../../styles/Insights/SentimentTreeview';
 import numeralLibs from 'numeral';
 import { fetchTermFromMap, hasChanged } from './shared';
+import { DEFAULT_EXTERNAL_SOURCE, DEFAULT_DATA_SOURCE } from '../../actions/constants';
 
 const TopRowHeight = 130;
 const parentTermsName = "Term Filters";
@@ -150,6 +152,20 @@ export default class SentimentTreeview extends React.Component {
         this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid);
     }
 
+    deleteExternalSourceId = () => {
+        const { dataSource, timespanType, datetimeSelection, zoomLevel, fromDate, toDate, termFilters, maintopic, bbox } = this.props;
+        const externalsourceid = DEFAULT_EXTERNAL_SOURCE;
+
+        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid);
+    }
+
+    deleteDataSource = () => {
+        const { externalsourceid, timespanType, datetimeSelection, zoomLevel, fromDate, toDate, termFilters, maintopic, bbox } = this.props;
+        const dataSource = DEFAULT_DATA_SOURCE;
+
+        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid);
+    }
+
     clearTerms(){
         const { maintopic } = this.props;
         this.handleDataFetch(maintopic, []);
@@ -213,6 +229,14 @@ export default class SentimentTreeview extends React.Component {
                             : undefined
                     }
                 </Subheader>
+                <div style={styles.activeFiltersView}>
+                    <ActiveFiltersView
+                        deleteExternalSourceId={this.deleteExternalSourceId}
+                        externalsourceid={this.props.externalsourceid}
+                        deleteDataSource={this.deleteDataSource}
+                        dataSource={this.props.dataSource}
+                    />
+                </div>
                 <div style={styles.searchBox}>
                     <TypeaheadSearch
                         dashboardRefreshFunc={this.handleDataFetch}

--- a/src/styles/Insights/ActiveFiltersView.css
+++ b/src/styles/Insights/ActiveFiltersView.css
@@ -1,0 +1,18 @@
+.active-filters-view > div {
+    position: relative;
+}
+.active-filters-view > div > svg {
+    position: absolute;
+    right: 0;
+}
+
+.active-filters-view--chip {
+    margin-bottom: 0.5em !important;
+}
+
+.active-filters-view--chip--label-container {
+    width: 140px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}

--- a/src/styles/Insights/SentimentTreeview.js
+++ b/src/styles/Insights/SentimentTreeview.js
@@ -10,6 +10,9 @@ export const styles = {
         verticalAlign: 'top',
         width: '100%'
     },
+    activeFiltersView: {
+        padding: '0px 20px 10px 20px'
+    },
     searchBox: {
         padding: '0px 20px 10px 20px'
     },


### PR DESCRIPTION
## Scenario overview ##

**Opening the dashboard: default filters are shown in chips**

![image](https://user-images.githubusercontent.com/1086421/30423327-d04c736e-9942-11e7-9694-4bc579a32251.png)

**Selecting a source in the top-sources chart: the selection is reflected in the chips**

![image](https://user-images.githubusercontent.com/1086421/30423368-ea48c75e-9942-11e7-9cfe-ee55e47778a6.png)

**Clearing the source filter via clicking on the X button on the chip: the removal is reflected in the charts**

![image](https://user-images.githubusercontent.com/1086421/30423418-049e824c-9943-11e7-935e-a2fa0dd57f66.png)

**Selecting two filters (source and pipeline) is also reflected in the chips**

![image](https://user-images.githubusercontent.com/1086421/30423490-4474c322-9943-11e7-8d53-86d12be277cb.png)

**It's possible to just clear one filter and leave the other one intact**

![image](https://user-images.githubusercontent.com/1086421/30423544-739c57a0-9943-11e7-86ce-2e9dbaae051f.png)

## Implementation notes ##

The screenshots above show a UI option where we always show the chips to make it explicit what the default value is for each filter. In 2aae159 I made a change to only show chips for non-default valued filters (so we wouldn't show the chip for "Source: all"). Both options are possible, just gotta make a call on which one we prefer. Here's a screenshot without the default-valued filters:

![image](https://user-images.githubusercontent.com/1086421/30424926-b45c07dc-9947-11e7-8552-ca25c79caf86.png)

It's pretty easy to add or remove filter chips. Just let me know exactly what you'd like to control via the chips. I didn't add a filter for `placeid` because it's not actually part of the synced data. I didn't add a filter for `maintopic` or `termFilters` because it would be highly redundant with the component just below:

![image](https://user-images.githubusercontent.com/1086421/30424879-8d007c2c-9947-11e7-9295-6617d5e6314b.png)

Unfortunately in the CSS one `!important` is necessary given that the MaterialUI chips set a bunch of styles on the elements instead of via classes... still better to have this one `!important` as opposed to having to put just a single CSS rule into the Javascript and therewith splitting the styling information over multiple files.