### PR TITLE
Hide facts page

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -42,7 +42,7 @@ class Header extends React.Component {
     return (
       <ul className="nav navbar-nav navbar-left">
         <li>{ this.renderDashboardLink() }</li>
-        <li>{ this.renderFactsLink() }</li>
+        {/*<li>{ this.renderFactsLink() }</li>*/}
         { this.props.siteKey === "dengue" && <li>{ this.renderPredictionsLink() }</li> }
       </ul>
     );


### PR DESCRIPTION
The facts page is a pinterest-style view of all recent events that came through the pipeline. We currently don't have the data-model to support queries to back this page.

We can't use the following tables:
- computedtiles
- heatmap
- popularplaces
- conjunctivetopics
- computedtrends

Since they don't surface the eventid column.

We can't use the following tables:
- eventtopics
- eventplaces

Since we can only query them by a restricted set of filters and in the facts view we want the ability to surface all events regardless of filters.

We can't use the following tables:
- events

Since the order defined on the table doesn't give us a list of events from most recent to least recent.

The events table defines a key of eventid and eventtime and a clustering order on eventtime which means that all events will be sorted within the eventid partition... however each eventid should be unique so every partition will only have a single item and querying across partitions (to get multiple events) doesn't give us any guarantee of the result order.

In order to support the facts page, we'd need a table that contains a meaningful partition breakdown inside of which it makes sense to query, like for example breaking down all events by pipeline:

```cql
CREATE TABLE events_by_pipeline(
  eventid text,
  eventtime timestamp,
  pipeline text,
  PRIMARY KEY(pipeline, eventtime, eventid)
) WITH CLUSTERING ORDER BY (eventtime DESC);
```

We can then query the new table like so:

```cql
SELECT eventid
FROM events_by_pipeline
WHERE pipeline = 'Twitter';
```

Note that we wouldn't be able to use a materialized view here since we can't query it as we'd wish:

```cql
CREATE MATERIALIZED VIEW events_by_pipeline AS
SELECT eventid, eventtime, pipeline
FROM events
WHERE eventid IS NOT NULL AND eventtime IS NOT NULL AND pipeline IS NOT NULL
PRIMARY KEY (pipeline, eventtime, eventid)
WITH CLUSTERING ORDER BY (eventtime DESC, eventid ASC);
```

The query above now fails since it may involve data filtering.

With the table query presented above, the results set will contain all the events for Twitter with the most recent events first. In the Facts page, we can then execute this query multiple times (once per pipeline) and display the events in columns (one per pipeline), a bit like this:

```
+------------+-------------+
| Twitter    | Facebook    |
+------------+-------------+
| eventA_t   | eventD_t'   |
| eventB_t-1 | eventE_t'-3 |
| eventC_t-2 | eventF_t'-7 |
+------------+-------------+
```

This is a non-trivial amount of work so it remains to be answered whether this is actually worth it, especially given that the newsfeed component in the dashboard already fulfills mostly the same use-cases as this feature would light up...

As such, I'd argue that for now it makes the most sense to disable the facts-page feature and focus on getting the rest of the pipeline in better shape. If the facts view turns out to be a deal-breaker in the future, we can always come back and see how to best implement it.