### PR TITLE
Fix js error when selecting filters

### DIFF
--- a/src/actions/Dashboard/index.js
+++ b/src/actions/Dashboard/index.js
@@ -23,7 +23,7 @@ function fetchFullChartData(fromDate, toDate, periodType, dataSource, maintopic,
     bbox, zoomLevel, conjunctivetopics, externalsourceid, timeseriesmaintopics, includeCsv, callback) {
 
     DashboardServices.getChartVisualizationData(periodType, maintopic, dataSource, fromDate, toDate, 
-        bbox, zoomLevel, conjunctivetopics, externalsourceid, timeseriesmaintopics, !!includeCsv,
+        bbox, zoomLevel, conjunctivetopics || [], externalsourceid, timeseriesmaintopics, !!includeCsv,
         (err, response, body) => ResponseHandler(err, response, body, callback));
 }
 


### PR DESCRIPTION
This was likely introduced in the change in a5e8ba4 to `reloadVisualizationState` which changed the empty array `[]` to the `conjunctivetopics` variable which may be null or undefined.

**Before**

![1](https://user-images.githubusercontent.com/1086421/30477389-440880ac-9a0d-11e7-9ca7-3940c0a8802e.PNG)
![2](https://user-images.githubusercontent.com/1086421/30477390-4410912a-9a0d-11e7-9c15-4c79373eea88.PNG)

**After**

![image](https://user-images.githubusercontent.com/1086421/30477403-514424a6-9a0d-11e7-8cf8-ef57346e67dd.png)
