### PR TITLE
Always pass through place on dashboard refresh

### DIFF
--- a/src/components/Insights/Dashboard.js
+++ b/src/components/Insights/Dashboard.js
@@ -167,8 +167,8 @@ export default class Dashboard extends React.Component {
   }
 
   refreshDashboard(includeCsv) {
-    const { dataSource, timespanType, termFilters, datetimeSelection, zoomLevel, maintopic, bbox, fromDate, toDate, externalsourceid } = this.filterLiterals();
-    this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv);
+    const { dataSource, place, timespanType, termFilters, datetimeSelection, zoomLevel, maintopic, bbox, fromDate, toDate, externalsourceid } = this.filterLiterals();
+    this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv, place);
   }
 
   timelineComponent() {

--- a/src/components/Insights/DataSelector.js
+++ b/src/components/Insights/DataSelector.js
@@ -50,10 +50,10 @@ export default class DataSelector extends React.Component {
         const formatter = constants.TIMESPAN_TYPES[timeType];
         const dates = momentGetFromToRange(timeSelection, formatter.format, formatter.rangeFormat);
         const { fromDate, toDate } = dates;
-        const { dataSource, maintopic, bbox, zoomLevel, termFilters, externalsourceid } = this.props;
+        const { dataSource, includeCsv, place, maintopic, bbox, zoomLevel, termFilters, externalsourceid } = this.props;
         const dateType = this.customDateEntered(timeType) ? formatter.rangeFormat : timeType;
 
-        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, timeSelection, dateType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid);
+        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, timeSelection, dateType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv, place);
     }
 
     handleChange(event, index, value) {

--- a/src/components/Insights/DataSourceFilter.js
+++ b/src/components/Insights/DataSourceFilter.js
@@ -30,9 +30,9 @@ const styles={
 
 export default class DataSourceFilter extends React.Component {
   radioButtonChanged(e, value){
-      const { timespanType, datetimeSelection, fromDate, toDate, maintopic, bbox, zoomLevel, conjunctivetopics, externalsourceid } = this.props;
+      const { timespanType, includeCsv, place, datetimeSelection, fromDate, toDate, maintopic, bbox, zoomLevel, conjunctivetopics, externalsourceid } = this.props;
     
-      this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, value, maintopic, bbox, zoomLevel, conjunctivetopics, externalsourceid);
+      this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, value, maintopic, bbox, zoomLevel, conjunctivetopics, externalsourceid, includeCsv, place);
   }
 
   renderDataSourceRadioOpts(iconStyle){

--- a/src/components/Insights/Maps/HeatMap.js
+++ b/src/components/Insights/Maps/HeatMap.js
@@ -48,12 +48,12 @@ export default class HeatMap extends React.Component {
   asyncInvokeDashboardRefresh(viewport) {
     if (this.refs.map) {
       const { dataSource, timespanType, termFilters, datetimeSelection, maintopic, externalsourceid,
-        fromDate, toDate } = this.props;
+        includeCsv, place, fromDate, toDate } = this.props;
       const zoom = this.refs.map.leafletElement.getZoom();
       const bbox = this.getLeafletBbox();
 
       this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, 
-        timespanType, dataSource, maintopic, bbox, zoom, Array.from(termFilters), externalsourceid);
+        timespanType, dataSource, maintopic, bbox, zoom, Array.from(termFilters), externalsourceid, includeCsv, place);
     }
   }
 

--- a/src/components/Insights/PopularLocationsChart.js
+++ b/src/components/Insights/PopularLocationsChart.js
@@ -19,10 +19,9 @@ export default class PopularLocationsChart extends React.Component {
     handleClick(data, activeIndex) {
         const { placeid, centroid, bbox } = data;
 
-        const { dataSource, timespanType, termFilters, defaultZoom, datetimeSelection, maintopic, externalsourceid, fromDate, toDate } = this.props;
+        const { dataSource, timespanType, termFilters, defaultZoom, datetimeSelection, maintopic, externalsourceid, fromDate, toDate, includeCsv } = this.props;
         const place = { placeid, centroid, bbox }
-        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, 
-            bbox, defaultZoom, Array.from(termFilters), externalsourceid, null, place);
+        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, defaultZoom, Array.from(termFilters), externalsourceid, includeCsv, place);
 
         this.setState({ activeIndex: activeIndex, selectedWofId: placeid });
     }

--- a/src/components/Insights/PopularSourcesChart.js
+++ b/src/components/Insights/PopularSourcesChart.js
@@ -16,9 +16,9 @@ export default class PopularSourcesChart extends React.Component {
     }
 
     handleClick(data, activeIndex) {
-        const { dataSource, timespanType, termFilters, datetimeSelection, zoomLevel, maintopic, bbox, fromDate, toDate } = this.props;
+        const { dataSource, timespanType, termFilters, datetimeSelection, zoomLevel, maintopic, bbox, fromDate, toDate, includeCsv, place } = this.props;
         const { name } = data;
-        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), name);
+        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), name, includeCsv, place);
         this.setState({ activeIndex });
     }
 

--- a/src/components/Insights/PopularTermsChart.js
+++ b/src/components/Insights/PopularTermsChart.js
@@ -16,9 +16,10 @@ export default class PopularTermsChart extends React.Component {
     }
 
     handleClick(data) {
-        const { dataSource, bbox, timespanType, termFilters, datetimeSelection, zoomLevel, externalsourceid, fromDate, toDate } = this.props;
+        const { dataSource, bbox, timespanType, termFilters, datetimeSelection, zoomLevel, externalsourceid, fromDate, toDate, includeCsv, place } = this.props;
+        const { defaultName } = data;
 
-        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, data.defaultName, bbox, zoomLevel, Array.from(termFilters), externalsourceid);
+        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, defaultName, bbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv, place);
     }
 
     refreshChart(props) {

--- a/src/components/Insights/SentimentTreeview.js
+++ b/src/components/Insights/SentimentTreeview.js
@@ -144,28 +144,28 @@ export default class SentimentTreeview extends React.Component {
     }
 
     handleDataFetch = (maintopic, termFilters, place) => {
-        const { dataSource, timespanType, datetimeSelection, defaultZoom, externalsourceid, fromDate, toDate } = this.props;
+        const { dataSource, timespanType, datetimeSelection, defaultZoom, externalsourceid, fromDate, toDate, includeCsv } = this.props;
         const bbox = place && place.bbox ? place.bbox : this.props.bbox;
         const zoomLevel = place ? defaultZoom : this.props.zoomLevel;
 
         maintopic = maintopic && !place ? maintopic : this.props.maintopic;
         termFilters = termFilters != null ? termFilters : this.props.termFilters;
         
-        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid, null, place);
+        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv, place);
     }
 
     deleteExternalSourceId = () => {
-        const { dataSource, timespanType, datetimeSelection, zoomLevel, fromDate, toDate, termFilters, maintopic, bbox } = this.props;
+        const { dataSource, timespanType, datetimeSelection, zoomLevel, fromDate, toDate, termFilters, maintopic, bbox, includeCsv, place } = this.props;
         const externalsourceid = DEFAULT_EXTERNAL_SOURCE;
 
-        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid);
+        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv, place);
     }
 
     deleteDataSource = () => {
-        const { externalsourceid, timespanType, datetimeSelection, zoomLevel, fromDate, toDate, termFilters, maintopic, bbox } = this.props;
+        const { externalsourceid, timespanType, datetimeSelection, zoomLevel, fromDate, toDate, termFilters, maintopic, bbox, includeCsv, place } = this.props;
         const dataSource = DEFAULT_DATA_SOURCE;
 
-        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid);
+        this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timespanType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv, place);
     }
 
     clearTerms(){

--- a/src/components/Insights/TimeSeriesGraph.js
+++ b/src/components/Insights/TimeSeriesGraph.js
@@ -84,7 +84,7 @@ export default class TimeSeriesGraph extends React.Component {
     }
 
     handleDataFetch() {
-        const { dataSource, timespanType, bbox, termFilters, timeSeriesGraphData, zoomLevel, externalsourceid, maintopic } = this.props;
+        const { dataSource, timespanType, bbox, termFilters, timeSeriesGraphData, zoomLevel, externalsourceid, maintopic, includeCsv, place } = this.props;
         const { startIndex, endIndex } = this.range;
         const fromDateSlice = timeSeriesGraphData.graphData[startIndex];
         const toDateSlice = timeSeriesGraphData.graphData[endIndex];
@@ -95,7 +95,7 @@ export default class TimeSeriesGraph extends React.Component {
             const toDate = this.momentFormat(toDateSlice.date, FromToDateFormat);
             const datetimeSelection = `${this.momentFormat(fromDateSlice.date, datetimeSelectionFormat)} - ${this.momentFormat(toDateSlice.date, datetimeSelectionFormat)}`
             const timeseriesType = constants.TIMESPAN_TYPES[timespanType].timeseriesType
-            this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timeseriesType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid);
+            this.props.flux.actions.DASHBOARD.reloadVisualizationState(fromDate, toDate, datetimeSelection, timeseriesType, dataSource, maintopic, bbox, zoomLevel, Array.from(termFilters), externalsourceid, includeCsv, place);
         }
     }
 


### PR DESCRIPTION
If we don't do this, if we select a place in the popularLocations chart and then select any other filter, the place filter will disappear.