### PR TITLE
Fetch stream values from graphql

### DIFF
--- a/src/actions/Dashboard/index.js
+++ b/src/actions/Dashboard/index.js
@@ -5,14 +5,32 @@ import constants from '../constants';
 import { ResponseHandler } from '../shared';
 import { momentGetFromToRange } from '../../utils/Utils';
 
+function toDataSources(streams) {
+    const dataSources = new Map();
+
+    const allDataSource = {display: 'All', sourceValues: streams.map(stream => stream.pipelineKey), icon: 'fa fa-share-alt', label: 'all'};
+    dataSources.set('all', allDataSource);
+
+    streams.forEach(stream => {
+        const streamDataSource = {display: stream.pipelineLabel, sourceValues: [stream.pipelineKey], label: stream.pipelineKey, icon: stream.pipelineIcon};
+        dataSources.set(stream.pipelineKey, streamDataSource);
+    });
+
+    const importDataSource = {display: 'Imported Events', sourceValues: ['custom'], label: 'custom', icon: 'fa fa-upload'};
+    dataSources.set('custom', importDataSource);
+
+    return dataSources;
+}
+
 function fetchCommonTerms(settings, callback, timespanType, fromDate, toDate) {
-    let { configuration, terms } = settings;
-    configuration = configuration.site.properties;
+    let { configuration, terms, streams } = settings;
+    configuration = configuration && configuration.site && configuration.site.properties;
+    const dataSources = toDataSources((streams && streams.streams) || []);
 
     DashboardServices.getCommonTerms(timespanType, fromDate, toDate, configuration.targetBbox, configuration.defaultZoomLevel,
         (error, response, body) => ResponseHandler(error, response, body, (err, topics) => {
             if (!err) {
-                callback(null, Object.assign({}, { terms }, { configuration }, topics ));
+                callback(null, Object.assign({}, { terms, dataSources }, { configuration }, topics ));
             } else {
                 callback(err, null);
             }

--- a/src/services/Admin/index.js
+++ b/src/services/Admin/index.js
@@ -51,7 +51,7 @@ const blacklistFragment = `fragment FortisDashboardView on BlacklistCollection {
 export const SERVICES = {
     getDashboardSiteDefinition(translationLanguage, callback) {
         const query = ` ${AdminFragments.siteSettingsFragment}
-                      ${AdminQueries.getPipelineDenfintion}`;
+                      ${AdminQueries.getPipelineDefinition}`;
 
         const variables = { translationLanguage };
         const host = process.env.REACT_APP_SERVICE_HOST

--- a/src/services/graphql/queries/Admin/index.js
+++ b/src/services/graphql/queries/Admin/index.js
@@ -32,7 +32,7 @@ export const getPipelineWatchlist = `query PipelineDefintion($translationLanguag
    terms: ${getPipelineTerms}
 }`;
 
-export const getPipelineDenfintion = `query PipelineDefintion($translationLanguage: String) {
+export const getPipelineDefinition = `query PipelineDefintion($translationLanguage: String) {
     terms: ${getPipelineTerms}
     configuration: ${getAdminSite}
 }`;

--- a/src/services/graphql/queries/Admin/index.js
+++ b/src/services/graphql/queries/Admin/index.js
@@ -28,12 +28,21 @@ export const getPipelineTerms = `siteTerms(translationLanguage:$translationLangu
   }
 }`;
 
+export const getPipelineStreams = `streams {
+  streams {
+    pipelineKey
+    pipelineIcon
+    pipelineLabel
+  }
+}`;
+
 export const getPipelineWatchlist = `query PipelineDefintion($translationLanguage: String!) {
    terms: ${getPipelineTerms}
 }`;
 
 export const getPipelineDefinition = `query PipelineDefintion($translationLanguage: String) {
     terms: ${getPipelineTerms}
+    streams: ${getPipelineStreams}
     configuration: ${getAdminSite}
 }`;
 

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -88,11 +88,15 @@ export const DataStore = Fluxxor.createStore({
     },
 
     intializeSettings(graphqlResponse) {
-        const { terms, configuration, topics } = graphqlResponse;
+        const { terms, configuration, topics, dataSources } = graphqlResponse;
         const { datetimeSelection, timespanType } = this.dataStore;
         const { defaultLanguage, logo, title, targetBbox, supportedLanguages, defaultZoomLevel } = configuration;
         const { fromDate, toDate } = convertDateValueToRange(datetimeSelection, timespanType);
 
+        // pretty bad hack... do this properly at some point by pulling the DATA_SOURCES into the store
+        constants.DATA_SOURCES = dataSources;
+
+        this.dataStore.dataSource = constants.DEFAULT_DATA_SOURCE;
         this.dataStore.fullTermList = makeMap(terms.edges, term=>term.name, term=>term);
         this.dataStore.title = title;
         this.dataStore.fromDate = fromDate;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1086421/30486107-d1fc98ea-9a2f-11e7-85d1-f1d54bd9c706.png)

This implementation is a bit of a hack, however doing this the right way (pulling the DATA_SOURCES into the DataStore) is quite a lot of effort because the constants.DATA_SOURCES is being used promiscuously in the code-base. I spent about an hour cleaning this up but it ended up being a reasonably large change (i.e., technical risk) so that it's worth doing this temporary hack for now.

There currently is a bug in the data: the pipelinekey in Cassandra is all-lowercase like "twitter" but the frontend assumes that it's capitalized like "Twitter". This issue will take care of itself once we update the streams table in Cassandra. More generally speaking, I had to edit quite a few of the columns in the streams table... we should start paying attention to that table and insert proper values into it instead of dummy values.