### PR TITLE
Display pretty name for sources if available

### DIFF
--- a/src/components/Insights/ActivityFeed.js
+++ b/src/components/Insights/ActivityFeed.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { SERVICES } from '../../services/Dashboard';
-import { SERVICES as ADMIN_SERVICES } from '../../services/Admin';
 import '../../styles/Insights/ActivityFeed.css';
 import styles from '../../styles/Insights/ActivityFeed';
 import Infinite from 'react-infinite';
@@ -61,24 +60,16 @@ export default class ActivityFeed extends React.Component {
     }
 
     fetchSentences(props, callback) {
-        const { bbox, fromDate, zoomLevel, toDate, maintopic, termFilters, enabledStreams } = props;
+        const { bbox, fromDate, zoomLevel, toDate, maintopic, termFilters, enabledStreams, trustedSources } = props;
         const { pageState, filteredSource } = this.state;
         const pipelinekeys = enabledStreams.get(filteredSource).sourceValues;
         const externalsourceid = props.externalsourceid !== constants.DEFAULT_EXTERNAL_SOURCE ? props.externalsourceid : null;
         const fulltextTerm = "";
+        const activeTrustedSources = trustedSources.filter(source => pipelinekeys.indexOf(source.pipelinekey) >= 0);
 
-        ADMIN_SERVICES.fetchTrustedSources(pipelinekeys, "", (trustedSourcesErr, trustedSourcesResponse, trustedSourcesBody) => {
-            let trustedSources;
-            if (!trustedSourcesErr && trustedSourcesResponse.statusCode === 200 && trustedSourcesBody.data) {
-                trustedSources = trustedSourcesBody.data.trustedSources.sources;
-            } else {
-                trustedSources = [];
-            }
-
-            SERVICES.FetchMessageSentences(externalsourceid, bbox, zoomLevel, fromDate, toDate, ActivityConsts.OFFSET_INCREMENT, pageState, [maintopic].concat(Array.from(termFilters)), pipelinekeys, fulltextTerm, (sentencesErr, response, body) => {
-                callback(sentencesErr, response, body, trustedSources);
-            });
-        })
+        SERVICES.FetchMessageSentences(externalsourceid, bbox, zoomLevel, fromDate, toDate, ActivityConsts.OFFSET_INCREMENT, pageState, [maintopic].concat(Array.from(termFilters)), pipelinekeys, fulltextTerm, (error, response, body) => {
+            callback(error, response, body, activeTrustedSources);
+        });
     }
 
     renderDataSourceTabs(iconStyle) {

--- a/src/components/Insights/Dashboard.js
+++ b/src/components/Insights/Dashboard.js
@@ -196,6 +196,7 @@ export default class Dashboard extends React.Component {
       <div key={'watchlist'}>
         <GraphCard>
           <SentimentTreeview
+            trustedSources={this.props.trustedSources}
             conjunctivetopics={this.props.conjunctivetopics}
             defaultBbox={this.props.settings.targetBbox}
             allSiteTopics={this.props.fullTermList}

--- a/src/components/Insights/Dashboard.js
+++ b/src/components/Insights/Dashboard.js
@@ -109,6 +109,7 @@ export default class Dashboard extends React.Component {
           {bbox.length ?
             <ActivityFeed
               allSiteTopics={this.props.fullTermList}
+              trustedSources={this.props.trustedSources}
               infiniteScrollHeight={this.isHeatmapFullScreen() ? contentAreaHeight : newsfeedResizedHeight > 0 ? newsfeedResizedHeight : contentRowHeight}
               {...this.filterLiterals() }
             />

--- a/src/components/Insights/SentimentTreeview.js
+++ b/src/components/Insights/SentimentTreeview.js
@@ -250,6 +250,7 @@ export default class SentimentTreeview extends React.Component {
                 </Subheader>
                 <div style={styles.searchBox}>
                     <TypeaheadSearch
+                        trustedSources={this.props.trustedSources}
                         dashboardRefreshFunc={this.handleDataFetch}
                         bbox={this.props.bbox}
                         enabledStreams={this.props.enabledStreams}

--- a/src/components/Insights/TypeaheadSearch.js
+++ b/src/components/Insights/TypeaheadSearch.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Autosuggest from 'react-autosuggest';
 import { fromMapToArray, fetchTermFromMap } from './shared';
 import { MenuItem, DropdownButton, InputGroup } from 'react-bootstrap';
-import { SERVICES } from '../../services/Admin';
 import { fetchLocationsFromFeatureService } from '../../services/featureService';
 import '../../styles/Insights/TypeaheadSearch.css';
 
@@ -91,30 +90,23 @@ export default class TypeaheadSearch extends React.Component {
   }
 
   fetchTrustedSourcesSuggestions = (value, callback) => {
-    const { dataSource, enabledStreams } = this.props;
+    const { dataSource, enabledStreams, trustedSources } = this.props;
     const pipelinekeys = enabledStreams.get(dataSource).sourceValues;
+    const activeTrustedSources = trustedSources.filter(source => pipelinekeys.indexOf(source.pipelinekey) >= 0);
 
-    SERVICES.fetchTrustedSources(pipelinekeys, value, (err, sources) => {
-      if (err) {
-        console.error(`Error while fetching sources matching '${value}': ${err}`);
-        callback([]);
-      } else {
-        const suggestions = sources.body.data.trustedSources.sources
-          .map(suggestion => {
-            const { displayname, externalsourceid, pipelinekey } = suggestion;
+    const suggestions = activeTrustedSources
+    .map(suggestion => {
+      const { displayname, externalsourceid, pipelinekey } = suggestion;
 
-            return Object.assign({},
-              {
-                name: displayname,
-                value: externalsourceid,
-                translatedname: externalsourceid,
-                icon: enabledStreams.get(pipelinekey).icon
-              }, suggestion);
-          });
-
-        callback(suggestions);
-      }
+      return Object.assign({}, {
+        name: displayname,
+        value: externalsourceid,
+        translatedname: externalsourceid,
+        icon: enabledStreams.get(pipelinekey).icon
+      }, suggestion);
     });
+
+    callback(suggestions);
   }
 
   onSuggestionsFetchRequested = ({ value }) => {

--- a/src/components/Insights/TypeaheadSearch.js
+++ b/src/components/Insights/TypeaheadSearch.js
@@ -12,7 +12,7 @@ export default class TypeaheadSearch extends React.Component {
     this.DATASETS = {
       LOCATION: { type: 'Location', icon: 'fa fa-map-marker', fetcher: this.fetchLocationSuggestions, description: 'Search for locations' },
       TERM: { type: 'Term', icon: 'fa fa-tag', fetcher: this.fetchTermSuggestions, description: 'Search for terms' },
-      SOURCE: { type: 'Source', icon: 'fa fa-share-alt', fetcher: this.fetchTrustedSourcesSuggestions, description: 'Search for trusted sources' }
+      SOURCE: { type: 'Source', icon: 'fa fa-share-alt', fetcher: this.fetchSourcesSuggestions, description: 'Search for trusted sources' }
     };
 
     this.state = {
@@ -89,7 +89,7 @@ export default class TypeaheadSearch extends React.Component {
     });
   }
 
-  fetchTrustedSourcesSuggestions = (value, callback) => {
+  fetchSourcesSuggestions = (value, callback) => {
     const { dataSource, enabledStreams, trustedSources } = this.props;
     const pipelinekeys = enabledStreams.get(dataSource).sourceValues;
     const activeTrustedSources = trustedSources.filter(source => pipelinekeys.indexOf(source.pipelinekey) >= 0);

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -90,7 +90,7 @@ export const DataStore = Fluxxor.createStore({
     },
 
     intializeSettings(graphqlResponse) {
-        const { terms, configuration, topics, dataSources, category } = graphqlResponse;
+        const { terms, configuration, topics, dataSources, category, trustedSources } = graphqlResponse;
         const { datetimeSelection, timespanType } = this.dataStore;
         const { defaultLanguage, logo, title, targetBbox, supportedLanguages, defaultZoomLevel } = configuration;
         const { fromDate, toDate } = convertDateValueToRange(datetimeSelection, timespanType);
@@ -110,6 +110,7 @@ export const DataStore = Fluxxor.createStore({
         this.dataStore.supportedLanguages = supportedLanguages;
         this.dataStore.maintopic = topics.edges.length ? topics.edges[0].name : '';
         this.dataStore.settings = configuration;
+        this.dataStore.trustedSources = trustedSources;
         this.syncChartDataToStore(graphqlResponse);
 
         this.dataStore.termFilters.clear();


### PR DESCRIPTION
As requested by @dmakogon, here's a change to use the trusted source display name (instead of id) when rendering.

Note that this is an optional UI improvement operation (not critical path) so if looking up the trusted sources display names fails, we still proceed with loading the sentences: it's better to show the sentences with an ugly id than not at all.

Screenshot showing result of new logic to replace Facebook page id with page name:

![image](https://user-images.githubusercontent.com/1086421/31356837-7e1628d6-ad0d-11e7-9d65-f9ee1a782b87.png)
