### PR TITLE
Add bare-bones implementation of facts page

### DIFF
--- a/src/actions/Dashboard/index.js
+++ b/src/actions/Dashboard/index.js
@@ -101,7 +101,7 @@ const methods = {
 
         seqAsync(
             //Load the site settings
-            callback => AdminServices.getDashboardSiteDefinition(null, category, (error, response, body) => ResponseHandler(error, response, body, callback)),
+            callback => AdminServices.getDashboardSiteDefinition(null, null, (error, response, body) => ResponseHandler(error, response, body, callback)),
             //Load the top 5 most popular terms
             (settings, callback) => fetchCommonTerms(settings, callback, timespanType, fromDate, toDate, category),
             //Merged Results(Settings + Full Term List + Popular Terms)

--- a/src/actions/Facts/index.js
+++ b/src/actions/Facts/index.js
@@ -2,8 +2,10 @@ import { SERVICES } from '../../services/Facts';
 import { ResponseHandler } from '../shared';
 
 const methods = {
-  loadFacts(pipelinekeys, callback) {
-    SERVICES.loadFacts(pipelinekeys, (error, response, body) => ResponseHandler(error, response, body, callback));
+  loadFacts(pipelinekeys, mainTerm, fromDate, toDate, callback) {
+    SERVICES.loadFacts(
+      pipelinekeys, mainTerm, fromDate, toDate,
+      (error, response, body) => ResponseHandler(error, response, body, callback));
   },
 };
 

--- a/src/actions/Facts/index.js
+++ b/src/actions/Facts/index.js
@@ -1,60 +1,12 @@
-/*import { SERVICES } from '../../services/Admin';
-import parallelAsync from 'async/parallel';
-import constants from '../constants';
-import { momentLastMonths } from '../../utils/Utils.js';
+import { SERVICES } from '../../services/Facts';
+import { ResponseHandler } from '../shared';
 
 const methods = {
-    load_facts(siteKey, limit, offset, filteredEdges = [], dataSources = [], fromDate="", toDate="", fulltextTerm="", langCode="en") {
-        let self = this;
-        let originalSource;
-        if (dataSources.length === 0) dataSources = ["tadaweb"];
-        let sourceProperties = ["title", "link", "originalSources"];
-        if (!fromDate || !toDate) {
-            let range = momentLastMonths(3);
-            fromDate = range.fromDate;
-            toDate = range.toDate;
-        }
-
-        SERVICES.FetchMessages(siteKey, originalSource, filteredEdges, langCode, limit, offset, fromDate, toDate, dataSources, fulltextTerm, sourceProperties, (err, reqRsp, body) => ResponseHandler(err, reqRsp, body, (error, response) => {
-            if (response && !error) {
-                self.dispatch(constants.FACTS.LOAD_FACTS_SUCCESS, { response });
-            } else {
-                console.warn('Error, could not load facts', error);
-                self.dispatch(constants.FACTS.LOAD_FACTS_FAIL, { error });
-            }
-        }));
-    },
-    load_tags(siteKey, sourceFilter=[], fromDate="", toDate="", query=""){
-        let self = this;
-        SERVICES.FetchTerms(siteKey, query, fromDate, toDate, sourceFilter, (err, response, body) => ResponseHandler(err, response, body, (error, response) => {
-            if (response && !error) {
-                self.dispatch(constants.FACTS.LOAD_TAGS, response);
-            } else {
-                console.error(`[${error}] occured while processing tag request`);
-            }
-        }));
-    },
-    load_settings(siteName){
-        let self = this;
-        SERVICES.getSiteDefintion(siteName, (err, response, body) => ResponseHandler(err, response, body, (error, graphqlResponse) => {
-            console.log(constants.FACTS.INITIALIZE);
-            if (graphqlResponse && !error) {
-                self.dispatch(constants.FACTS.INITIALIZE, graphqlResponse.siteDefinition.sites[0]);
-            }else{
-                console.error(`[${error}] occured while processing message request`);
-            }
-        }));
-    },
-    save_page_state(pageState) {
-        this.dispatch(constants.FACTS.SAVE_PAGE_STATE, pageState);
-    },
-    changeLanguage(language){
-       this.dispatch(constants.FACTS.CHANGE_LANGUAGE, language);
-    }
+  loadFacts(pipelinekeys, callback) {
+    SERVICES.loadFacts(pipelinekeys, (error, response, body) => ResponseHandler(error, response, body, callback));
+  },
 };
 
 module.exports = {
-    constants: constants,
-    methods: {FACTS: methods}
+  methods: {FACTS: methods}
 };
-*/

--- a/src/components/Facts/FactsList.js
+++ b/src/components/Facts/FactsList.js
@@ -114,7 +114,7 @@ export const FactsList = createReactClass({
           </p>
           <h3 className="title truncate-2">
             <a onClick={() => this.openItemDetails(item)}>
-              {item.title}
+              {this.renderCardTitle(item)}
             </a>
           </h3>
           <div className="tags">
@@ -123,6 +123,14 @@ export const FactsList = createReactClass({
         </div>
       </div>
     );
+  },
+
+  renderCardTitle(item) {
+    if (item.messageid.indexOf('Facebook') > -1 && item.messageid.indexOf('comment') > -1) {
+      return item.summary;
+    }
+
+    return item.title;
   },
 
   openItemDetails(item) {

--- a/src/components/Facts/FactsList.js
+++ b/src/components/Facts/FactsList.js
@@ -44,6 +44,7 @@ export const FactsList = createReactClass({
   getInitialState() {
     return {
       facts: [],
+      loading: false,
     };
   },
 
@@ -60,9 +61,16 @@ export const FactsList = createReactClass({
   },
 
   render() {
-    const { facts } = this.state;
+    const { loading, facts } = this.state;
 
-    const mainContent = facts && facts.length ? this.renderFacts(facts) : this.renderNoFacts();
+    let mainContent;
+    if (loading) {
+      mainContent = this.renderLoading();
+    } else if (facts && facts.length) {
+      mainContent = this.renderFacts(facts);
+    } else {
+      mainContent = this.renderNoFacts();
+    }
 
     return (
       <div id="facts">
@@ -178,18 +186,25 @@ export const FactsList = createReactClass({
   },
 
   loadFacts() {
-    const pipelinekeys = this.props.enabledStreams.get(PIPELINE_ALL).sourceValues;
+    const { loading } = this.state;
+    if (loading) {
+      return;
+    }
+
     const { maintopic, fromDate, toDate } = this.props;
     if (!maintopic || !fromDate || !toDate) {
       return;
     }
 
+    const pipelinekeys = this.props.enabledStreams.get(PIPELINE_ALL).sourceValues;
     methods.FACTS.loadFacts(pipelinekeys, maintopic, fromDate, toDate, (err, data) => {
       if (err) return console.error(`Error fetching facts: ${err}`);
 
       this.setState({
         facts: this.sortByEventTime((data && data.facts && data.facts.features) || []),
+        loading: false,
       });
     });
+    this.setState({ loading: true });
   },
 });

--- a/src/components/Facts/FactsList.js
+++ b/src/components/Facts/FactsList.js
@@ -137,8 +137,9 @@ export const FactsList = createReactClass({
 
   loadFacts() {
     const pipelinekeys = this.props.enabledStreams.get(PIPELINE_ALL).sourceValues;
+    const { maintopic, fromDate, toDate } = this.props;
 
-    methods.FACTS.loadFacts(pipelinekeys, (err, data) => {
+    methods.FACTS.loadFacts(pipelinekeys, maintopic, fromDate, toDate, (err, data) => {
       if (err) return console.error(`Error fetching facts: ${err}`);
       if (!data || !data.facts || !data.facts.features || !data.facts.features.length) return console.error(`No facts for ${pipelinekeys}`);
 

--- a/src/components/Facts/FactsList.js
+++ b/src/components/Facts/FactsList.js
@@ -1,138 +1,68 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import Fluxxor from 'fluxxor';
-import ListView from './ListView';
-import { Link } from 'react-router';
-import { SERVICES as DashboardServices } from '../../services/Dashboard';
-import { getHumanDate, containsEqualValues, UCWords, momentLastMonths } from '../../utils/Utils.js';
-import { fragmentToArray, changeFactsUrl } from '../../utils/Fact.js';
-import SuperSelectField from 'material-ui-superselectfield/lib/superSelectField'
 import Chip from 'material-ui/Chip';
+import { PIPELINE_ALL } from '../../actions/constants';
+import { getHumanDate, UCWords } from '../../utils/Utils.js';
+import { methods } from '../../actions/Facts';
+import DialogBox from '../dialogs/DialogBox';
+import ListView from './ListView';
 
 // Material UI style overrides
 const styles = {
   radioButton: {
-    width: "auto",
-    float: "left",
-    marginRight: "20px",
+    width: 'auto',
+    float: 'left',
+    marginRight: '20px',
   },
   checkbox: {
-    marginTop: "6px",
-    marginRight: "20px",
+    marginTop: '6px',
+    marginRight: '20px',
   },
   iconStyle: {
-    marginRight: "4px",
+    marginRight: '4px',
   },
   button: {
-    marginLeft: "5px",
-    height: "20px",
+    marginLeft: '5px',
+    height: '20px',
     lineHeight: '1',
-    textAlign: "center",
+    textAlign: 'center',
   },
   chip: {
-    display: "inline-block",
-    margin: "2px",
+    display: 'inline-block',
+    margin: '2px',
   }
 };
 
-const FluxMixin = Fluxxor.FluxMixin(React);
-const StoreWatchMixin = Fluxxor.StoreWatchMixin("FactsStore");
-
 export const FactsList = createReactClass({
-  mixins: [FluxMixin, StoreWatchMixin],
-
-  displayName: 'FactsList',
-  sources: ["tadaweb"],
-
-  // Card sizes
   _cardWidth: 320,
   _cardHeight: 200,
   _gutter: 20,
+  _subtractedElements: ['.navbar', '#filters'],
 
-  // Select tags
-  _select: "selectFilter",
-  _isSelectOpen: false,
-
-  resetState(state, selectedTags = []) {
-    state.loaded = false;
-    state.facts = [];
-    state.skip = 0;
-    state.selectedTags = selectedTags;
-    return state;
-  },
-
-  getStateFromFlux() {
-    const state = this.getFlux().store("FactsStore").getState();
-    const tags = fragmentToArray(this.props.tags);
-    if (!containsEqualValues(state.selectedTags, tags)) {
-      return this.resetState(state, tags);
-    }
-    return state;
-  },
-
-  componentWillReceiveProps(nextProps) {
-    let state = this.getStateFromFlux();
-    const curr = fragmentToArray(this.props.tags);
-    const next = fragmentToArray(nextProps.tags);
-    if (!containsEqualValues(curr, next)) {
-      state = this.resetState(state, next);
-    }
-    this.setState(state);
+  getInitialState() {
+    return {
+      loaded: false,
+      facts: [],
+    };
   },
 
   componentDidMount() {
-    // get list of unique tags
-    if (this.state.tags.length === 0) {
-      this.loadTags();
-    }
-    // get first page of all facts
-    if (this.state.facts.length === 0) {
-      this.loadFacts();
-    }
-  },
-
-  componentDidUpdate(prevProps, prevState) {
-    if (!this.state.loaded) {
-      this.loadFacts();
-    }
+    this.loadFacts();
   },
 
   render() {
-    // Loading state
-    if (!this.state.loaded) {
-      return (<div className="loadingPage"><p>Loading facts&hellip;</p></div>);
+    const { loaded, facts } = this.state;
+
+    if (!loaded) {
+      return this.renderLoading();
     }
 
-    // No results
-    if (this.state.facts.length === 0) {
-      return (
-        <div id="facts" >
-          <div className="noResults">
-            <h3>No facts found.</h3>
-            <Link to={`/site/${this.props.siteKey}/facts/`}>Reset filters</Link>
-          </div>
-        </div>);
+    if (!facts || !facts.length) {
+      return this.renderNoFacts();
     }
 
-    const facts = this.state.facts;
-    const select = this.renderSelect();
-    const chips = this.renderChips();
-
-    // List view
     return (
       <div id="facts">
-        <div id="filters">
-          <div className="container-fluid">
-            <div className="row">
-              <div className="col-md-9 hidden-sm">
-                <div id="tags">{chips}</div>
-              </div>
-              <div className="col-md-3 col-sm-12">
-                <div id="select">{select}</div>
-              </div>
-            </div>
-          </div>
-        </div>
         <ListView ref="factsListView"
           minCardWidth={this._cardWidth}
           maxCardHeight={this._cardHeight}
@@ -140,145 +70,82 @@ export const FactsList = createReactClass({
           items={facts}
           renderCardItem={this.renderCardItem}
           loadItems={this.loadFacts}
-          subtractedElements={['.navbar', '#filters']}
-          />
+          subtractedElements={this._subtractedElements}
+        />
+        <DialogBox ref="dialogBox" {...this.props} />
       </div>
     );
   },
 
-  translate(sentence, fromLanguage, toLanguage, factId) {
-    const self = this;
-    DashboardServices.translateSentence(sentence, fromLanguage, toLanguage, (translatedSentence, error) => {
-      if (translatedSentence) {
-        self.state.facts.forEach(fact => {
-          if (fact.id === factId) {
-            fact.language = toLanguage;
-            fact.title = translatedSentence
-          }
-        });
-        self.setState({
-          elements: self.state
-        });
-      }
-      else {
-        console.error(`[${error}] occured while translating sentence`);
-      }
-    }
+  renderLoading() {
+    return (
+      <div className="loadingPage">
+        <p>Loading facts&hellip;</p>
+      </div>
+    );
+  },
+
+  renderNoFacts() {
+    return (
+      <div id="facts" >
+        <div className="noResults">
+          <h3>No facts found.</h3>
+        </div>
+      </div>
+    );
+  },
+
+  renderTag(tag) {
+    return (
+      <Chip key={tag} style={styles.chip}>
+        {UCWords(tag)}
+      </Chip>
     );
   },
 
   renderCardItem(data, style) {
     const item = data.properties;
-    const dateString = getHumanDate(item.createdtime, "MM/DD/YYYY");
-    const title = item.sentence;
+
     return (
       <div className="cell" style={style}>
         <div className="card">
-          <p className="date">{dateString}
-            {this.state.language !== item.language ? <button className="btn btn-primary btn-sm" style={styles.button}
-              onClick={() => this.translate(title, item.language, this.state.language, item.messageid)}>Translate</button> : ''}
+          <p className="date">
+            {getHumanDate(item.eventtime, 'x', 'MM/DD/YYYY')}
           </p>
-          <h3 className="title truncate-2"><Link to={`/site/${this.props.siteKey}/facts/detail/${item.messageid}`}>{title}</Link></h3>
+          <h3 className="title truncate-2">
+            <a onClick={() => this.refs.dialogBox.open(item.messageid)}>
+              {item.title}
+            </a>
+          </h3>
           <div className="tags">
-            {item.edges.sort().map((tag) => {
-              const name = UCWords(tag);
-              return <Chip key={tag} style={styles.chip} onTouchTap={(event) => this.handleSelectTag(tag)}>{name}</Chip>;
-            }, this)}
+            {item.edges.sort().map(this.renderTag)}
           </div>
         </div>
       </div>
     );
   },
 
-  handleSelectTag(tag) {
-    changeFactsUrl(this.props.siteKey, [tag]);
-  },
-
-  renderSelect() {
-    if (this.state.tags.length === 0) {
-      return;
-    }
-
-    const dataSource = this.state.tags
-    .sort((a, b) => (a.name.toLowerCase() > b.name.toLowerCase()) || (a.name.toLowerCase() === b.name.toLowerCase()) - 1)
-    .map((x, index) => {
-      const tag = x.name.toLowerCase();
-      return (
-        <div key={tag} value={tag} label={tag}>{UCWords(x.name)}</div>
-      );
+  sortByEventTime(events) {
+    return events.sort((a, b) => {
+      const timeA = parseInt(a.properties.eventtime, 10);
+      const timeB = parseInt(b.properties.eventtime, 10);
+      if (timeA > timeB) return 1;
+      if (timeA < timeB) return -1;
+      return 0;
     });
-
-    return (
-      <SuperSelectField
-        ref={this._select}
-        name={this._select}
-        hintText="Filter"
-        multiple
-        onSelect={(selectedValues) => this.setState({ 'selectedTags': selectedValues })}
-        value={this.state.selectedTags}
-        selectionsRenderer={this.handleSelectRenderer}
-        menuProps={{ maxHeight: 460 }}
-        style={{ width: "100%" }}
-        >
-        {dataSource}
-      </SuperSelectField>
-    );
-  },
-
-  // Using custom renderer to trigger page update only once the multiple select menu has closed
-  handleSelectRenderer(values, hintText) {
-    if (this.refs[this._select] && this.refs[this._select].state.isOpen === false) {
-      changeFactsUrl(this.props.siteKey, this.state.selectedTags);
-    }
-    return hintText;
-  },
-
-  renderChips() {
-    const selectedTags = this.getSelectedTagNames();
-    return (
-      <div className="chips">
-        {selectedTags.map((name) => {
-          const tag = name.toLowerCase();
-          return (
-            <Chip key={tag} style={{ margin: 2 }} onRequestDelete={(event) => this.handleRequestDelete(tag)}>{UCWords(name)}</Chip>
-          );
-        }, this)}
-      </div>
-    );
-  },
-
-  handleRequestDelete(name) {
-    // create mutable clone of selected tags for splicing the deleted tag
-    const selectedTags = this.state.selectedTags.slice();
-    const index = selectedTags.indexOf(name);
-    if (index > -1) {
-      selectedTags.splice(index, 1);
-      changeFactsUrl(this.props.siteKey, selectedTags);
-    } else {
-      console.error(`Unable to delete tag: ${name}`);
-    }
-  },
-
-  loadTags() {
-    const range = momentLastMonths(3);
-    const fromDate = range.fromDate;
-    const toDate = range.toDate;
-    this.getFlux().actions.FACTS.load_tags(this.props.siteKey, this.sources, fromDate, toDate);
   },
 
   loadFacts() {
-    // NB: filter edges param uses lowercase names
-    const selectedTags = this.state.selectedTags.slice().map(s => s.toLowerCase());
-    this.getFlux().actions.FACTS.load_facts(this.props.siteKey, this.state.pageSize, this.state.skip, selectedTags, this.sources);
-  },
+    const pipelinekeys = this.props.enabledStreams.get(PIPELINE_ALL).sourceValues;
 
-  // returns the selected (case sensitive) tag names from term collection
-  getSelectedTagNames() {
-    const selectedTags = this.state.selectedTags.slice().map(s => s.toLowerCase());
-    const filteredTags = this.state.tags.filter(x => selectedTags.indexOf(x.name.toLowerCase()) > -1);
-    return filteredTags.reduce((prev, curr) => {
-      prev.push(curr['name']);
-      return prev;
-    }, []);
+    methods.FACTS.loadFacts(pipelinekeys, (err, data) => {
+      if (err) return console.error(`Error fetching facts: ${err}`);
+      if (!data || !data.facts || !data.facts.features || !data.facts.features.length) return console.error(`No facts for ${pipelinekeys}`);
+
+      this.setState({
+        facts: this.sortByEventTime(data.facts.features),
+        loaded: true,
+      });
+    });
   },
 });

--- a/src/components/Facts/FactsList.js
+++ b/src/components/Facts/FactsList.js
@@ -113,7 +113,7 @@ export const FactsList = createReactClass({
             {getHumanDate(item.eventtime, 'x', 'MM/DD/YYYY')}
           </p>
           <h3 className="title truncate-2">
-            <a onClick={() => this.refs.dialogBox.open(item.messageid)}>
+            <a onClick={() => this.openItemDetails(item)}>
               {item.title}
             </a>
           </h3>
@@ -123,6 +123,10 @@ export const FactsList = createReactClass({
         </div>
       </div>
     );
+  },
+
+  openItemDetails(item) {
+    this.refs.dialogBox.open(item.messageid);
   },
 
   sortByEventTime(events) {

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -42,7 +42,7 @@ class Header extends React.Component {
     return (
       <ul className="nav navbar-nav navbar-left">
         <li>{ this.renderDashboardLink() }</li>
-        {/*<li>{ this.renderFactsLink() }</li>*/}
+        <li>{ this.renderFactsLink() }</li>
         { this.props.siteKey === "dengue" && <li>{ this.renderPredictionsLink() }</li> }
       </ul>
     );

--- a/src/components/Insights/DataSelector.js
+++ b/src/components/Insights/DataSelector.js
@@ -132,16 +132,16 @@ export default class DataSelector extends React.Component {
                             : undefined
                         }
                     </div>
-                    <div>
+                    {this.props.hideHeatmapToggle ? null : <div>
                         <button id="save-button" type="button" className="btn btn-primary btn-sm" onClick={()=>this.props.toggleHeatmapSize()}>
                             <span className="fa fa-expand" aria-hidden="true">
                             </span>
                             <span>{this.props.heatmapToggleText}</span>
                         </button>
-                    </div>
-                    <div>
+                    </div>}
+                    {this.props.hideDataSourceFilter ? null : <div>
                         <DataSourceFilter {...this.props} />
-                    </div>
+                    </div>}
                 </div>
             </div>
         );

--- a/src/components/Insights/TypeaheadSearch.js
+++ b/src/components/Insights/TypeaheadSearch.js
@@ -9,11 +9,10 @@ export default class TypeaheadSearch extends React.Component {
   constructor(props) {
     super(props);
 
-    this.DATASETS = {
-      LOCATION: { type: 'Location', icon: 'fa fa-map-marker', fetcher: this.fetchLocationSuggestions, description: 'Search for locations' },
-      TERM: { type: 'Term', icon: 'fa fa-tag', fetcher: this.fetchTermSuggestions, description: 'Search for terms' },
-      SOURCE: { type: 'Source', icon: 'fa fa-share-alt', fetcher: this.fetchSourcesSuggestions, description: 'Search for trusted sources' }
-    };
+    this.DATASETS = {};
+    this.DATASETS.TERM = { type: 'Term', icon: 'fa fa-tag', fetcher: this.fetchTermSuggestions, description: 'Search for terms' };
+    if (!props.excludeLocations) this.DATASETS.LOCATION = { type: 'Location', icon: 'fa fa-map-marker', fetcher: this.fetchLocationSuggestions, description: 'Search for locations' };
+    if (!props.excludeSources) this.DATASETS.SOURCE = { type: 'Source', icon: 'fa fa-share-alt', fetcher: this.fetchSourcesSuggestions, description: 'Search for trusted sources' };
 
     this.state = {
       suggestions: [],

--- a/src/routes/FactsPage.js
+++ b/src/routes/FactsPage.js
@@ -17,7 +17,7 @@ export const FactsPage = createReactClass({
   render() {
     return (
       <div className="report">
-        <FactsList {...this.getStateFromFlux()} />
+        <FactsList {...this.getStateFromFlux()} flux={this.props.flux} />
       </div>
     );
   }

--- a/src/services/Facts/index.js
+++ b/src/services/Facts/index.js
@@ -3,7 +3,7 @@ import * as FactsQueries from '../graphql/queries/Facts';
 import { fetchGqlData } from '../shared';
 
 export const SERVICES = {
-  loadFacts(pipelinekeys, callback) {
+  loadFacts(pipelinekeys, mainTerm, fromDate, toDate, callback) {
     const gqlEndpoint = 'messages';
 
     const selectionFragments = `
@@ -16,6 +16,9 @@ export const SERVICES = {
     `;
 
     const variables = {
+      mainTerm,
+      fromDate,
+      toDate,
       pipelinekeys
     };
 

--- a/src/services/Facts/index.js
+++ b/src/services/Facts/index.js
@@ -1,0 +1,24 @@
+import * as FactsFragments from '../graphql/fragments/Facts';
+import * as FactsQueries from '../graphql/queries/Facts';
+import { fetchGqlData } from '../shared';
+
+export const SERVICES = {
+  loadFacts(pipelinekeys, callback) {
+    const gqlEndpoint = 'messages';
+
+    const selectionFragments = `
+      ${FactsFragments.factsFragment}
+    `;
+
+    const query = `
+      ${selectionFragments}
+      ${FactsQueries.FactsQuery}
+    `;
+
+    const variables = {
+      pipelinekeys
+    };
+
+    fetchGqlData(gqlEndpoint, { variables, query }, callback);
+  },
+}

--- a/src/services/graphql/fragments/Facts/index.js
+++ b/src/services/graphql/fragments/Facts/index.js
@@ -1,0 +1,21 @@
+export const factsFragment = `
+fragment FortisFactsView on FeatureCollection {
+  features {
+    properties {
+      messageid,
+      summary,
+      edges,
+      eventtime,
+      sourceeventid,
+      externalsourceid,
+      sentiment,
+      language,
+      pipelinekey,
+      link,
+      title,
+      link
+    }
+    coordinates
+  }
+}
+`.trim();

--- a/src/services/graphql/queries/Facts/index.js
+++ b/src/services/graphql/queries/Facts/index.js
@@ -1,6 +1,6 @@
 export const FactsQuery = `
-query FetchFacts($pipelinekeys: [String]!) {
-  facts: byPipeline(pipelinekeys: $pipelinekeys) {
+query FetchFacts($pipelinekeys: [String]!, $mainTerm: String!, $fromDate: String!, $toDate: String!) {
+  facts: byPipeline(pipelinekeys: $pipelinekeys, mainTerm: $mainTerm, fromDate: $fromDate, toDate: $toDate) {
     ...FortisFactsView
   }
 }

--- a/src/services/graphql/queries/Facts/index.js
+++ b/src/services/graphql/queries/Facts/index.js
@@ -1,0 +1,7 @@
+export const FactsQuery = `
+query FetchFacts($pipelinekeys: [String]!) {
+  facts: byPipeline(pipelinekeys: $pipelinekeys) {
+    ...FortisFactsView
+  }
+}
+`.trim();

--- a/src/styles/Facts/Facts.css
+++ b/src/styles/Facts/Facts.css
@@ -7,6 +7,9 @@
     padding: 20px;
 }
 
+#facts .dateRow,
+#facts .noResults,
+#facts .loadingPage,
 #facts .ReactListView > * {
     background: #F3F3EC;
     margin: 0 auto;

--- a/src/styles/Facts/Facts.css
+++ b/src/styles/Facts/Facts.css
@@ -7,12 +7,26 @@
     padding: 20px;
 }
 
-#facts .dateRow,
+#facts .inputs-container,
 #facts .noResults,
 #facts .loadingPage,
 #facts .ReactListView > * {
     background: #F3F3EC;
     margin: 0 auto;
+}
+
+#facts .inputs-container {
+    display: flex;
+    justify-content: space-around;
+}
+
+#facts .inputs-container > .input-group,
+#facts .inputs-container > .dateRow {
+    align-self: center;
+}
+
+#facts .inputs-container > .input-group {
+    width: 300px;
 }
 
 #facts .cell {


### PR DESCRIPTION
For now this is just rendering a pinterest-style board of events for all pipelines, in reverse chronological order.

We can add more features (like filtering or infinite scroll) once we're more stabilized, collected some real-world data and have a clearer understanding of the requirements of the facts page as compared to the newsfeed component.

![image](https://user-images.githubusercontent.com/1086421/32248856-6a199a32-be5d-11e7-8f40-76793b200718.png)

Related backend changes:
- https://github.com/CatalystCode/project-fortis-pipeline/pull/165
- https://github.com/CatalystCode/project-fortis-services/pull/163